### PR TITLE
Various lbc.py improvements/fixes

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -291,7 +291,7 @@ def are_cluster_roles_created():
 # Takes helm style "key1=value1,key2=value2" string and returns a list of (key, value)
 # pairs. Supports quoting, escaped or non-escaped commas and values with commas inside, eg.:
 #  parse_set_string('am=amg01:9093,amg02:9093') -> [('am', 'amg01:9093,amg02:9093')]
-#  parse_set_string('am="am01,am02",es=NodePort') -> [('alertManagers', 'am01,am02'), ('es', 'NodePort')]
+#  parse_set_string('am="am01,am02",es=NodePort') -> [('am', 'am01,am02'), ('es', 'NodePort')]
 def parse_set_string(s):
     # Keyval pair with commas allowed
     keyval_pair_re = re.compile(r'(\w+)=([\w\-\+\*\:\\,]+)')
@@ -327,7 +327,7 @@ def install(creds_file):
     version_arg = ('--version ' + args.version) if args.version != None else '--devel'
 
     # Helm args are separated from lbc.py args by double dash, filter it out
-    helm_args = ' '.join([arg for arg in args.helm if arg != '--'])
+    helm_args = ' '.join([arg for arg in args.helm if arg != '--']) + ' '
 
     # Add '--set' arguments to helm_args
     if args.set != None:
@@ -553,6 +553,15 @@ def debug_dump(args):
                              show_stderr=False)
     if returncode == 0:
         dump(archive, 'kubectl-describe-all.txt', stdout)
+    else:
+        fail(failure_msg + 'unable to describe k8s resources in {} namespace'
+                .format(args.namespace))
+
+    # Describe PVCs
+    stdout, returncode = run('kubectl --namespace {} get pvc'.format(args.namespace),
+                             show_stderr=False)
+    if returncode == 0:
+        dump(archive, 'kubectl-get-pvc.txt', stdout)
     else:
         fail(failure_msg + 'unable to describe k8s resources in {} namespace'
                 .format(args.namespace))

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -326,8 +326,10 @@ def install(creds_file):
     creds_arg = '--values ' + creds_file
     version_arg = ('--version ' + args.version) if args.version != None else '--devel'
 
-    # Helm args are separated from lbc.py args by double dash, filter it out
-    helm_args = ' '.join([arg for arg in args.helm if arg != '--']) + ' '
+    helm_args = ''
+    if len(args.helm) > 0:
+        # Helm args are separated from lbc.py args by double dash, filter it out
+        helm_args += ' '.join([arg for arg in args.helm if arg != '--']) + ' '
 
     # Add '--set' arguments to helm_args
     if args.set != None:
@@ -603,8 +605,12 @@ def setup_args(argv):
                         action='store_true')
     install.add_argument('--export-yaml', help='export resource yaml to stdout',
                         choices=['creds', 'console'])
-    install.add_argument('--reuse-resources', help='try to reuse PVCs and/or cluster roles from a previous install',
-                        action='store_true')
+
+    install.add_argument('--reuse-resources', dest='reuse_resources',
+        help='try to reuse PVCs and/or cluster roles from a previous install', action='store_true')
+    install.add_argument('--no-reuse-resources', dest='reuse_resources', help=argparse.SUPPRESS, action='store_false')
+    install.set_defaults(reuse_resources=True)
+
     install.add_argument('--local-chart', help='set to location of local chart tarball')
     install.add_argument('--chart', help='chart name to install from the repository', default='enterprise-suite')
     install.add_argument('--repo', help='helm chart repository', default='https://repo.lightbend.com/helm-charts')

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -651,11 +651,7 @@ def main(argv):
     global args
     args = setup_args(argv)
 
-    if args.subcommand == 'verify':
-        if not args.skip_checks:
-            check_kubectl()
-        check_install()
-    
+    force_verify = False
     if args.subcommand == 'install':
         creds = import_credentials()
 
@@ -674,7 +670,15 @@ def main(argv):
         with tempfile.NamedTemporaryFile('w') as creds_tempfile:
             write_temp_credentials(creds_tempfile, creds)
             install(creds_tempfile.name)
-    
+
+        if args.wait:
+            force_verify = True
+
+    if args.subcommand == 'verify' or force_verify:
+        if not args.skip_checks:
+            check_kubectl()
+        check_install()
+ 
     if args.subcommand == 'uninstall':
         if not args.skip_checks:
             check_helm()

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -318,7 +318,7 @@ def parse_set_string(s):
                 if matchlen == len(left) or left[matchlen] == ',':
                     left = left[matchlen+1:]
                 else:
-                    raise ValueError('unexpected characted "{}"'.format(left[matchlen]))
+                    raise ValueError('unexpected character "{}"'.format(left[matchlen]))
             else:
                 raise ValueError('unable to parse "{}"'.format(left))
         return result

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -61,6 +61,7 @@ class SetStrParsingTest(unittest.TestCase):
 
         # Multiple key value pairs
         self.assertEqual(lbc.parse_set_string("key1=val1,key2=val2"), [("key1", "val1"), ("key2", "val2")])
+        self.assertEqual(lbc.parse_set_string("key1=val1,key2=val2,b=c"), [("key1", "val1"), ("key2", "val2"), ("b", "c")])
 
         # Quoted values
         self.assertEqual(lbc.parse_set_string("key=\"value\""), [("key", "value")])
@@ -78,6 +79,10 @@ class SetStrParsingTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             lbc.parse_set_string("key=val1,key2=val1,val2")
+        
+        with self.assertRaises(ValueError):
+            lbc.parse_set_string("key=val1,key2==val1")
+
 
 class LbcTest(unittest.TestCase):
     def setUpFakeChartfile(self):

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -132,14 +132,14 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--no-reuse-resources'])
     
     def test_install_wait(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --wait')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--wait'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--wait', '--no-reuse-resources'])
 
     def test_install_helm_failed(self):
         # Failed previous install, no PVCs or clusterroles found for reuse
@@ -176,14 +176,14 @@ class LbcTest(unittest.TestCase):
 
         # Expect install to fail when previous install is still pending
         with self.assertRaises(TestFailException):
-            lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
+            lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--no-reuse-resources'])
 
     def test_upgrade(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=0)
         expect_cmd(r'helm upgrade enterprise-suite es-repo/enterprise-suite --devel --values \S+ ')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--no-reuse-resources'])
 
     def test_force_install(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
@@ -191,21 +191,21 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm status enterprise-suite', returncode=0)
         expect_cmd(r'helm delete --purge enterprise-suite')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--force-install'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--force-install', '--no-reuse-resources'])
 
     def test_helm_args(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --fakearg')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--', '--set', 'minikube=true', '--fakearg'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--no-reuse-resources' , '--', '--set', 'minikube=true', '--fakearg'])
 
     def test_helm_set(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --set usePersistentVolumes=true ')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'minikube=true', '--set', 'usePersistentVolumes=true'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'minikube=true', '--set', 'usePersistentVolumes=true', '--no-reuse-resources'])
 
     def test_helm_set_array(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
@@ -213,33 +213,33 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set alertmanagers=alertmgr-00\\,alertmgr-01\\,alertmgr-02 ')
 
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'alertmanagers=alertmgr-00,alertmgr-01,alertmgr-02'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'alertmanagers=alertmgr-00,alertmgr-01,alertmgr-02', '--no-reuse-resources'])
 
     def test_specify_version(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --version 1\.0\.0-rc\.9 --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--version=1.0.0-rc.9'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--version=1.0.0-rc.9', '--no-reuse-resources'])
 
     def test_install_local_chart(self):
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install chart.tgz --name enterprise-suite --namespace lightbend --devel --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--local-chart=chart.tgz'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--local-chart=chart.tgz', '--no-reuse-resources'])
 
     def test_install_override_repo(self):
         expect_cmd(r'helm repo add es-repo https://repo.bintray.com/helm')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--repo=https://repo.bintray.com/helm'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--repo=https://repo.bintray.com/helm', '--no-reuse-resources'])
 
     def test_install_override_name(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status lb-console', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name lb-console --namespace lightbend --devel --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--helm-name=lb-console'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--helm-name=lb-console', '--no-reuse-resources'])
 
     def test_install_reuse_pvcs(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -48,6 +48,37 @@ tempdir = ''
 def test_make_tempdir():
     return tempdir
 
+class SetStrParsingTest(unittest.TestCase):
+    def test_parsing(self):
+        # Empty
+        self.assertEqual(lbc.parse_set_string(""), [])
+
+        # Most trivial case
+        self.assertEqual(lbc.parse_set_string("key=value"), [("key", "value")])
+
+        # Escaped commas
+        self.assertEqual(lbc.parse_set_string("key=val1\\,val2"), [("key", "val1,val2")])
+
+        # Multiple key value pairs
+        self.assertEqual(lbc.parse_set_string("key1=val1,key2=val2"), [("key1", "val1"), ("key2", "val2")])
+
+        # Quoted values
+        self.assertEqual(lbc.parse_set_string("key=\"value\""), [("key", "value")])
+        self.assertEqual(lbc.parse_set_string("key=\"val1,val2\""), [("key", "val1,val2")])
+
+        # Quoted values + multiple pairs
+        self.assertEqual(lbc.parse_set_string("key1=\"val1,val2\",key2=val3"), [("key1", "val1,val2"), ("key2", "val3")])
+
+        # Error cases
+        with self.assertRaises(ValueError):
+            lbc.parse_set_string("key=val1,val2,key2=val3")
+
+        with self.assertRaises(ValueError):
+            lbc.parse_set_string("val1,val2")
+
+        with self.assertRaises(ValueError):
+            lbc.parse_set_string("key=val1,key2=val1,val2")
+
 class LbcTest(unittest.TestCase):
     def setUpFakeChartfile(self):
         # Create tempdir & fake chartfile there for export yaml tests.
@@ -168,14 +199,14 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set "minikube=true" --set "usePersistentVolumes=true"')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --set usePersistentVolumes=true ')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'minikube=true', '--set', 'usePersistentVolumes=true'])
 
     def test_helm_set_array(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set "alertmanagers=alertmgr-00\\,alertmgr-01\\,alertmgr-02"')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set alertmanagers=alertmgr-00\\,alertmgr-01\\,alertmgr-02 ')
 
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'alertmanagers=alertmgr-00,alertmgr-01,alertmgr-02'])
 

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -139,6 +139,20 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --wait')
+        
+        # Verify happens automatically when --wait is provided
+        expect_cmd(r'kubectl --namespace lightbend get deploy/es-console --no-headers',
+                   stdout='es-console 1 1 1 1 15m')
+        expect_cmd(r'kubectl --namespace lightbend get deploy/grafana-server --no-headers',
+                   stdout='grafana-server 1 1 1 1 15m')
+        expect_cmd(r'kubectl --namespace lightbend get deploy/prometheus-alertmanager --no-headers',
+                   stdout='prometheus-alertmanager 1 1 1 1 15m')
+        expect_cmd(r'kubectl --namespace lightbend get deploy/prometheus-kube-state-metrics --no-headers',
+                   stdout='prometheus-kube-state-metrics 1 1 1 1 15m')
+        expect_cmd(r'kubectl --namespace lightbend get deploy/prometheus-server --no-headers',
+                   stdout='prometheus-server 2 2 2 2 15m')
+
+
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--wait', '--no-reuse-resources'])
 
     def test_install_helm_failed(self):

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -145,13 +145,12 @@ class LbcTest(unittest.TestCase):
                    stdout='es-console 1 1 1 1 15m')
         expect_cmd(r'kubectl --namespace lightbend get deploy/grafana-server --no-headers',
                    stdout='grafana-server 1 1 1 1 15m')
-        expect_cmd(r'kubectl --namespace lightbend get deploy/prometheus-alertmanager --no-headers',
-                   stdout='prometheus-alertmanager 1 1 1 1 15m')
         expect_cmd(r'kubectl --namespace lightbend get deploy/prometheus-kube-state-metrics --no-headers',
                    stdout='prometheus-kube-state-metrics 1 1 1 1 15m')
         expect_cmd(r'kubectl --namespace lightbend get deploy/prometheus-server --no-headers',
                    stdout='prometheus-server 2 2 2 2 15m')
-
+        expect_cmd(r'kubectl --namespace lightbend get deploy/prometheus-alertmanager --no-headers',
+                   stdout='prometheus-alertmanager 1 1 1 1 15m')
 
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--wait', '--no-reuse-resources'])
 
@@ -308,12 +307,12 @@ class LbcTest(unittest.TestCase):
         # Grafana is not running
         expect_cmd(r'kubectl --namespace monitoring get deploy/grafana-server --no-headers',
                    stdout='grafana-server 1 1 1 0 15m')
-        expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-alertmanager --no-headers',
-                   stdout='prometheus-alertmanager 1 1 1 1 15m')
         expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-kube-state-metrics --no-headers',
                    stdout='prometheus-kube-state-metrics 1 1 1 1 15m')
         expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-server --no-headers',
                    stdout='prometheus-server 2 2 2 2 15m')
+        expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-alertmanager --no-headers',
+                   stdout='prometheus-alertmanager 1 1 1 1 15m')
 
         # Expect verify to fail
         with self.assertRaises(TestFailException):
@@ -324,12 +323,12 @@ class LbcTest(unittest.TestCase):
                    stdout='es-console 1 1 1 1 15m')
         expect_cmd(r'kubectl --namespace monitoring get deploy/grafana-server --no-headers',
                    stdout='grafana-server 1 1 1 1 15m')
-        expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-alertmanager --no-headers',
-                   stdout='prometheus-alertmanager 1 1 1 1 15m')
         expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-kube-state-metrics --no-headers',
                    stdout='prometheus-kube-state-metrics 1 1 1 1 15m')
         expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-server --no-headers',
                    stdout='prometheus-server 2 2 2 2 15m')
+        expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-alertmanager --no-headers',
+                   stdout='prometheus-alertmanager 1 1 1 1 15m')
 
         lbc.main(['verify', '--skip-checks', '--namespace=monitoring'])
 


### PR DESCRIPTION
For https://github.com/lightbend/es-backend/issues/476, https://github.com/lightbend/es-backend/issues/473, https://github.com/lightbend/es-backend/issues/474, https://github.com/lightbend/es-backend/issues/472

This PR makes following changes to `lbc.py`:
- Better `--set` value parsing with helm syntax compatibility
- Include PV info in debug dumps
- Try to reuse clusterrole and PV resources by default
- Option to skip checking alertmanager when doing `verify` for use with external alertmanagers
- Always verify install when `--wait` flag is set