### PR TITLE
Fix check_resource_list() issue in lbc.py

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -269,7 +269,7 @@ def check_resource_list(cmd, expected, fail_msg):
                 fail('Multiple lines with resource {} found: {}'.format(res, str(found_lines)))
 
         if not all_found and len(found_resources) > 0:
-            fail(fail_msg.format(str(found_pvcs)))
+            fail(fail_msg.format(str(found_resources)))
 
         return all_found
     return False


### PR DESCRIPTION
Get the following stack trace without this fix:

```
Traceback (most recent call last):
  File "./scripts/lbc.py", line 706, in <module>
    main(sys.argv[1:])
  File "./scripts/lbc.py", line 682, in main
    install(creds_tempfile.name)
  File "./scripts/lbc.py", line 414, in install
    if are_cluster_roles_created():
  File "./scripts/lbc.py", line 290, in are_cluster_roles_created
    fail_msg='Found some cluster roles from previous console install, but not all: {}. Please clean them up manually.'
  File "./scripts/lbc.py", line 272, in check_resource_list
    fail(fail_msg.format(str(found_pvcs)))
NameError: global name 'found_pvcs' is not defined
```