### PR TITLE
Show imageCredentials.registry in /version output of es-console

### DIFF
--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -169,9 +169,15 @@ data:
           "description": {{ .Chart.Description | quote }},
           "version": {{ .Chart.Version | quote }},
           {{- range $k, $v := .Values }}
-          {{- if and (ne $k "imageCredentials") ($v) }}
+            {{- if eq $k "imageCredentials" }}
+              {{- range $k2, $v2 := . }}
+                {{- if and (eq $k2 "registry") ($v2) }}
+          "imageCredentials": { {{ $k2 |quote }}: {{ $v2 | quote}} },
+                {{- end}}
+              {{- end}}
+            {{- else}}
           {{ $k | quote }}: {{ $v | quote }},
-          {{- end}}
+            {{- end}}
           {{- end}}
           "name": {{ .Chart.Name | quote }}\n}';
         add_header Content-Type application/json;


### PR DESCRIPTION
This is for https://github.com/lightbend/es-backend/issues/520

This exposes `imageCredentials.registry` in the `/version` output of the es-console endpoint.

e.g. With non-default values used in `values.yaml`:
```
imageCredentials:
  registry: some-crap.registry.bintray.io
  username: dontshow
  password: omg
```

get this excerpt from es-console.yaml:

```
      location ~ (.*)/version$ {
        return 200 '{
          "description": "Lightbend Console",
          "version": "1.0.0-rc.6",
          [...]
          "imageCredentials": { "registry": "some-crap.registry.bintray.io" },
          "imagePullPolicy": "IfNotPresent",
          [...]
```

Only `imageCredentials.registry` is shown, not either of `imageCredentials.username` or `imageCredentials.password`.