### PR TITLE
Tweak /version output so it's valid JSON

### DIFF
--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -179,7 +179,8 @@ data:
           {{ $k | quote }}: {{ $v | quote }},
             {{- end}}
           {{- end}}
-          "name": {{ .Chart.Name | quote }}\n}';
+          "name": {{ .Chart.Name | quote }}
+        }';
         add_header Content-Type application/json;
       }
 

--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -175,7 +175,7 @@ data:
           "imageCredentials": { {{ $k2 |quote }}: {{ $v2 | quote}} },
                 {{- end}}
               {{- end}}
-            {{- else}}
+            {{- else if ($v) }}
           {{ $k | quote }}: {{ $v | quote }},
             {{- end}}
           {{- end}}


### PR DESCRIPTION
The output from the `/version` endpoint is supposed to be valid JSON.  Currently it ends with:
   `"name": "enterprise-suite"\n}`
(That's a literal '\' and 'n' there which is invalid.)

We also don't cope with entries that have a null value.  This generates text that looks like:
   `"podUID": ,`

These changes fix both of those issues.  (In the latter case, we won't output anything for that entry.)