### PR TITLE
Fix lbc.py exception handling

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -94,10 +94,10 @@ def run(cmd, timeout=None, stdin=None, show_stderr=True):
         if len(stderr) > 0 and show_stderr:
             printerr(stderr)
         returncode = proc.returncode
-    except OSError, o:
-        stdout=o.strerror
-        returncode=o.errno
-    except Exception, e:
+    except OSError as e:
+        stdout=e.strerror
+        returncode=e.errno
+    except Exception as e:
         stdout=str(e)
         returncode=1
     finally:


### PR DESCRIPTION
This format is the old syntax, that doesn't work in later versions of
python 2. I've updated it to the modern syntax.

On my machine I get:

```
+ /home/james/lightbend/helm-charts/enterprise-suite/tests/../scripts/lbc.py install --namespace=console-backend-e2e --local-chart=/home/james/lightbend/helm-charts/enterprise-suite/tests/.. -- --set usePersistentVolumes=true,defaultStorageClass=gp2 --wait                        
  File "/home/james/lightbend/helm-charts/enterprise-suite/tests/../scripts/lbc.py", line 97                                                                                                                                
    except OSError, o:                                                                                                                                                                                                                                                                  
```

Python 2.7.15

Related to https://github.com/lightbend/es-backend/issues/420