### PR TITLE
Remove obsolete cluster role check from lbc.py

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -50,11 +50,6 @@ CONSOLE_PVCS = [
     'prometheus-storage'
 ]
 
-CONSOLE_CLUSTER_ROLES = [
-    'kube-state-metrics',
-    'prometheus-server'
-]
-
 DEFAULT_TIMEOUT=3
 
 # Parsed commandline args
@@ -282,14 +277,6 @@ def are_pvcs_created(namespace):
         fail_msg='Found some PVCs ({}) from previous console install, but not all expected: {}.\nTo avoid data loss, please remove them manually'
     )
 
-# Checks for console cluster roles
-def are_cluster_roles_created():
-    return check_resource_list(
-        cmd='kubectl get clusterroles --no-headers',
-        expected=CONSOLE_CLUSTER_ROLES,
-        fail_msg='Found some cluster roles ({}) from previous console install, but not all expected: {}. Please remove them manually.'
-    )
-
 # Takes helm style "key1=value1,key2=value2" string and returns a list of (key, value)
 # pairs. Supports quoting, escaped or non-escaped commas and values with commas inside, eg.:
 #  parse_set_string('am=amg01:9093,amg02:9093') -> [('am', 'amg01:9093,amg02:9093')]
@@ -409,11 +396,6 @@ def install(creds_file):
             if are_pvcs_created(args.namespace):
                 printerr('info: found existing PVCs from previous console installation, will reuse them')
                 helm_args += ' --set createPersistentVolumes=false'
-
-            # Reuse cluster roles if present
-            if are_cluster_roles_created():
-                printerr('info: found existing cluster roles from previous console installation, will reuse them')
-                helm_args += ' --set createClusterRoles=false'
 
         if should_upgrade:
             execute('helm upgrade {} {} {} {} {}'

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -162,7 +162,6 @@ class LbcTest(unittest.TestCase):
                    stdout='LAST DEPLOYED: Tue Nov 13 09:59:46 2018\nNAMESPACE: lightbend\nSTATUS: FAILED\nNOTES: blah')
         expect_cmd(r'helm delete --purge enterprise-suite')
         expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
-        expect_cmd(r'kubectl get clusterroles --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
 
@@ -177,7 +176,6 @@ class LbcTest(unittest.TestCase):
                    stdout=('alertmanager-storage Bound pvc-a3815792-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
                            'es-grafana-storage Bound pvc-a3824cbc-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
                            'prometheus-storage Bound pvc-a382f4c1-e744-11e8-a15b-080027dccb43 256Gi RWO standard 1h\n'))
-        expect_cmd(r'kubectl get clusterroles --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set createPersistentVolumes=false')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
 
@@ -262,19 +260,7 @@ class LbcTest(unittest.TestCase):
                    stdout=('alertmanager-storage Bound pvc-a3815792-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
                            'es-grafana-storage Bound pvc-a3824cbc-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
                            'prometheus-storage Bound pvc-a382f4c1-e744-11e8-a15b-080027dccb43 256Gi RWO standard 1h\n'))
-        expect_cmd(r'kubectl get clusterroles --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set createPersistentVolumes=false')
-
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--reuse-resources'])
-
-    def test_install_reuse_cluster_roles(self):
-        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
-        expect_cmd(r'helm repo update')
-        expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
-        expect_cmd(r'kubectl get clusterroles --no-headers',
-                   stdout='prometheus-kube-state-metrics 72m\nprometheus-server 72m')
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set createClusterRoles=false')
 
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--reuse-resources'])
 
@@ -283,7 +269,6 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
-        expect_cmd(r'kubectl get clusterroles --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
 
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--reuse-resources'])


### PR DESCRIPTION
The cluster roles are namespaced now, so this check doesn't make sense.

Also, it doesn't work if the installer has limited permissions.

Related to https://github.com/lightbend/es-backend/issues/420