### PR TITLE
Don't add createPersistentVolumes=false if PVCs exist

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -396,7 +396,8 @@ def install(creds_file):
                 .format(args.helm_name, chart_ref, version_arg,
                         creds_arg, helm_args))
         else:
-            if are_pvcs_created(args.namespace):
+            createPVs = len(filter(lambda x: 'createPersistentVolumes=false' in x, sys.argv)) == 0
+            if createPVs and are_pvcs_created(args.namespace):
                 printerr('info: Found existing PVCs from a previous console installation.')
                 printerr('info: Please remove them with `kubectl delete pvc`, or pass --set createPersistentVolumes=false.')
                 printerr('info: Otherwise, the install may fail.')
@@ -592,11 +593,6 @@ def setup_args(argv):
                         action='store_true')
     install.add_argument('--export-yaml', help='export resource yaml to stdout',
                         choices=['creds', 'console'])
-
-    install.add_argument('--reuse-resources', dest='reuse_resources',
-                         help='try to reuse PVCs and/or cluster roles from a previous install', action='store_true')
-    install.add_argument('--no-reuse-resources', dest='reuse_resources', help=argparse.SUPPRESS, action='store_false')
-    install.set_defaults(reuse_resources=True)
 
     install.add_argument('--local-chart', help='set to location of local chart tarball')
     install.add_argument('--chart', help='chart name to install from the repository', default='enterprise-suite')

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -391,17 +391,16 @@ def install(creds_file):
         if args.wait:
             helm_args += ' --wait'
 
-        if args.reuse_resources or status == 'failed':
-            # Reuse PVCs if present
-            if are_pvcs_created(args.namespace):
-                printerr('info: found existing PVCs from previous console installation, will reuse them')
-                helm_args += ' --set createPersistentVolumes=false'
-
         if should_upgrade:
             execute('helm upgrade {} {} {} {} {}'
                 .format(args.helm_name, chart_ref, version_arg,
                         creds_arg, helm_args))
         else:
+            if are_pvcs_created(args.namespace):
+                printerr('info: Found existing PVCs from a previous console installation.')
+                printerr('info: Please remove them with `kubectl delete pvc`, or pass --set createPersistentVolumes=false.')
+                printerr('info: Otherwise, the install may fail.')
+
             execute('helm install {} --name {} --namespace {} {} {} {}'
                 .format(chart_ref, args.helm_name, args.namespace,
                         version_arg, creds_arg, helm_args))

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -131,13 +131,15 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--no-reuse-resources'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
     
     def test_install_wait(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --wait')
         
         # Verify happens automatically when --wait is provided
@@ -152,7 +154,7 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'kubectl --namespace lightbend get deploy/prometheus-alertmanager --no-headers',
                    stdout='prometheus-alertmanager 1 1 1 1 15m')
 
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--wait', '--no-reuse-resources'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--wait'])
 
     def test_install_helm_failed(self):
         # Failed previous install, no PVCs or clusterroles found for reuse
@@ -176,7 +178,7 @@ class LbcTest(unittest.TestCase):
                    stdout=('alertmanager-storage Bound pvc-a3815792-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
                            'es-grafana-storage Bound pvc-a3824cbc-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
                            'prometheus-storage Bound pvc-a382f4c1-e744-11e8-a15b-080027dccb43 256Gi RWO standard 1h\n'))
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set createPersistentVolumes=false')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
 
     def test_install_not_finished(self):
@@ -187,91 +189,78 @@ class LbcTest(unittest.TestCase):
 
         # Expect install to fail when previous install is still pending
         with self.assertRaises(TestFailException):
-            lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--no-reuse-resources'])
+            lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
 
     def test_upgrade(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=0)
         expect_cmd(r'helm upgrade enterprise-suite es-repo/enterprise-suite --devel --values \S+ ')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--no-reuse-resources'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
 
     def test_force_install(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=0)
         expect_cmd(r'helm delete --purge enterprise-suite')
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--force-install', '--no-reuse-resources'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--force-install'])
 
     def test_helm_args(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --fakearg')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--no-reuse-resources' , '--', '--set', 'minikube=true', '--fakearg'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--', '--set', 'minikube=true', '--fakearg'])
 
     def test_helm_set(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --set usePersistentVolumes=true ')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'minikube=true', '--set', 'usePersistentVolumes=true', '--no-reuse-resources'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'minikube=true', '--set', 'usePersistentVolumes=true'])
 
     def test_helm_set_array(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set alertmanagers=alertmgr-00\\,alertmgr-01\\,alertmgr-02 ')
 
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'alertmanagers=alertmgr-00,alertmgr-01,alertmgr-02', '--no-reuse-resources'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'alertmanagers=alertmgr-00,alertmgr-01,alertmgr-02'])
 
     def test_specify_version(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --version 1\.0\.0-rc\.9 --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--version=1.0.0-rc.9', '--no-reuse-resources'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--version=1.0.0-rc.9'])
 
     def test_install_local_chart(self):
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'helm install chart.tgz --name enterprise-suite --namespace lightbend --devel --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--local-chart=chart.tgz', '--no-reuse-resources'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--local-chart=chart.tgz'])
 
     def test_install_override_repo(self):
         expect_cmd(r'helm repo add es-repo https://repo.bintray.com/helm')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--repo=https://repo.bintray.com/helm', '--no-reuse-resources'])
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--repo=https://repo.bintray.com/helm'])
 
     def test_install_override_name(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status lb-console', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name lb-console --namespace lightbend --devel --values \S+')
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--helm-name=lb-console', '--no-reuse-resources'])
-
-    def test_install_reuse_pvcs(self):
-        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
-        expect_cmd(r'helm repo update')
-        expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers',
-                   stdout=('alertmanager-storage Bound pvc-a3815792-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
-                           'es-grafana-storage Bound pvc-a3824cbc-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
-                           'prometheus-storage Bound pvc-a382f4c1-e744-11e8-a15b-080027dccb43 256Gi RWO standard 1h\n'))
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set createPersistentVolumes=false')
-
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--reuse-resources'])
-
-    def test_install_reuse_resources_negative(self):
-        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
-        expect_cmd(r'helm repo update')
-        expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
-
-        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--reuse-resources'])
+        expect_cmd(r'helm install es-repo/enterprise-suite --name lb-console --namespace lightbend --devel --values \S+')
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--helm-name=lb-console'])
 
     def test_uninstall(self):
         expect_cmd(r'helm status enterprise-suite', returncode=0,


### PR DESCRIPTION
Otherwise, it will actually delete the existing PVCs on an upgrade.

Instead, simply warn the user and let them make the correct choice.

The new output looks like:

```
$ scripts/lbc.py install --namespace=jsravn-console --local-chart=. --set usePersistentVolumes=true --set defaultStorageClass=gp2
info: Found existing PVCs from a previous console installation.
info: Please remove them with `kubectl delete pvc`, or pass --set createPersistentVolumes=false.
info: Otherwise, the install may fail.
helm install . --name enterprise-suite --namespace jsravn-console --devel --values /tmp/tmpEqcPas --set usePersistentVolumes=true --set defaultStorageClass=gp2 
Error: release enterprise-suite failed: persistentvolumeclaims "alertmanager-storage" already exists


Command 'helm install . --name enterprise-suite --namespace jsravn-console --devel --values /tmp/tmpEqcPas --set usePersistentVolumes=true --set defaultStorageClass=gp2 ' failed!
```