### PR TITLE
Improve lbc.py credentials check robustness

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -178,11 +178,12 @@ def check_credentials(creds):
     registry = 'https://lightbend-docker-commercial-registry.bintray.io/v2'
     api_url = registry + '/enterprise-suite/es-monitor-api/tags/list'
 
-    # Use curl for checking credentials by default, only do urllib2 backup in case curl doesn't work (eg. not installed)
-    stdout, returncode = run('curl -s -o /dev/null -w "%{http_code}" ' + ' --user {}:{} {}'
-        .format(creds[0], creds[1], url), DEFAULT_TIMEOUT)
-    if returncode == 0 and stdout == '200':
-        return True
+    # Use curl for checking credentials by default, only do urllib2 backup in case curl isn't installed
+    stdout, returncode = run('curl --version')
+    if returncode == 0:
+        stdout, returncode = run('curl -s -o /dev/null -w "%{http_code}" ' + ' --user {}:{} {}'
+            .format(creds[0], creds[1], api_url), DEFAULT_TIMEOUT, show_stderr=True)
+        return int(stdout) == 200
 
     # Set up basic auth with given creds
     req = url.Request(api_url)

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -178,6 +178,12 @@ def check_credentials(creds):
     registry = 'https://lightbend-docker-commercial-registry.bintray.io/v2'
     api_url = registry + '/enterprise-suite/es-monitor-api/tags/list'
 
+    # Use curl for checking credentials by default, only do urllib2 backup in case curl doesn't work (eg. not installed)
+    stdout, returncode = run('curl -s -o /dev/null -w "%{http_code}" ' + ' --user {}:{} {}'
+        .format(creds[0], creds[1], url), DEFAULT_TIMEOUT)
+    if returncode == 0 and stdout == '200':
+        return True
+
     # Set up basic auth with given creds
     req = url.Request(api_url)
     basic_auth = base64.b64encode('{}:{}'.format(creds[0], creds[1]))

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -221,8 +221,9 @@ def preinstall_check(creds, minikube=False, minishift=False):
     # TODO: Check if RBAC rules for tiller are set up
 
     if not check_credentials(creds):
-        fail('Your credentials do not appear to be correct' +
-                 ' - unable to make authenticated request to lightbend docker registry')
+        printerr('Your credentials might not be correct' +
+                 ' - unable to make authenticated request to lightbend docker registry; ' +
+                 'proceeding with the installation anyway')
 
 # Returns one of 'deployed', 'failed', 'pending', 'deleting', 'notfound' or 'unknown'
 def install_status(release_name):


### PR DESCRIPTION
We still have problems with default python on OS X. This PR should address it with two improvements:

- Make credentials check failure non-critical and continue the install with a warning
- Try to use curl, if present on the system, for the authentication request