### PR TITLE
Fix helm upgrade on an old release

### DIFF
--- a/enterprise-suite/templates/alertmanager-deployment.yaml
+++ b/enterprise-suite/templates/alertmanager-deployment.yaml
@@ -12,6 +12,8 @@ spec:
   strategy:
     # Always Recreate to ensure the PVs get released. It's not possible to have two replicas sharing a PV during deployment.
     type: Recreate
+    # Needed for helm upgrade to succeed.
+    rollingUpdate: null
 
   selector:
     matchLabels:

--- a/enterprise-suite/templates/es-grafana-deployment.yaml
+++ b/enterprise-suite/templates/es-grafana-deployment.yaml
@@ -11,6 +11,8 @@ spec:
   strategy:
     # Always Recreate to ensure the PVs get released. It's not possible to have two replicas sharing a PV during deployment.
     type: Recreate
+    # Needed for helm upgrade to succeed.
+    rollingUpdate: null
 
   template:
     metadata:

--- a/enterprise-suite/templates/prometheus-deployment.yaml
+++ b/enterprise-suite/templates/prometheus-deployment.yaml
@@ -11,6 +11,7 @@ spec:
   strategy:
     # Always Recreate to ensure the PVs get released. It's not possible to have two replicas sharing a PV during deployment.
     type: Recreate
+    rollingUpdate: null
 
   selector:
     matchLabels:

--- a/enterprise-suite/templates/prometheus-deployment.yaml
+++ b/enterprise-suite/templates/prometheus-deployment.yaml
@@ -11,6 +11,7 @@ spec:
   strategy:
     # Always Recreate to ensure the PVs get released. It's not possible to have two replicas sharing a PV during deployment.
     type: Recreate
+    # Needed for helm upgrade to succeed.
     rollingUpdate: null
 
   selector:


### PR DESCRIPTION
That was using the rolling update strategy. This fixes the helm
error that occurs when doing an upgrade.

```
Error: UPGRADE FAILED: Deployment.apps "prometheus-alertmanager" is
invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified
when strategy `type` is 'Recreate' && Deployment.apps "grafana-server"
is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified
when strategy `type` is 'Recreate' && Deployment.apps
"prometheus-server" is invalid: spec.strategy.rollingUpdate: Forbidden:
may not be specified when strategy `type` is 'Recreate'
```

Fix https://github.com/lightbend/es-backend/issues/496