### PR TITLE
Allow for specification of add'l Grafana configs in values.yaml

### DIFF
--- a/enterprise-suite/templates/es-grafana-deployment.yaml
+++ b/enterprise-suite/templates/es-grafana-deployment.yaml
@@ -50,6 +50,10 @@ spec:
             value: "false"
           - name: GF_ANALYTICS_CHECK_FOR_UPDATES
             value: "false"
+          {{- range $key, $val := .Values.esGrafanaEnvVars }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+          {{- end }}
         ports:
           - containerPort: 3000
         lifecycle:

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -122,3 +122,16 @@ prometheusVolumeSize: 256Gi
 alertmanagerVolumeSize: 32Gi
 # Grafana volume size - used for storing users, custom dashboards, and plugins.
 esGrafanaVolumeSize: 32Gi
+
+#################################################
+# Grafana environment variables
+#
+# Any additional configuration for Grafana, using environment variables as specified at
+# http://docs.grafana.org/installation/configuration/#using-environment-variables.
+#
+esGrafanaEnvVars:
+#  for example...
+#  GF_SMTP_ENABLED: true
+#  GF_SMTP_HOST: smtp.gmail.com:465
+#  GF_SMTP_USER: username
+#  GF_SMTP_PASSWORD: password


### PR DESCRIPTION
With the sample configs uncommented, we see this after running
`helm template . -x templates/es-grafana-deployment.yaml -f values.yaml`
(Things are unchanged if no values are provided.)

```
[...]
        env:
          [...]
          - name: GF_ANALYTICS_CHECK_FOR_UPDATES
            value: "false"
          - name: GF_SMTP_ENABLED
            value: "true"
          - name: GF_SMTP_HOST
            value: "smtp.gmail.com:465"
          - name: GF_SMTP_PASSWORD
            value: "password"
          - name: GF_SMTP_USER
            value: "username"
        ports:
[...]
```
