### PR TITLE
whitesource scan docker images after smoke tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ jobs:
     script:
     - scripts/setup-minikube-for-linux.sh || travis_terminate 1
     - make -C enterprise-suite minikube-backend-tests
+    # update whitesource docker image CVE report based on above images
+    - curl -sLJO https://github.com/whitesource/fs-agent-distribution/raw/master/standAlone/whitesource-fs-agent.jar
+    - java -jar whitesource-fs-agent.jar -apiKey ${WHITESOURCE_API_KEY} -c .ws.conf
 
   - name: Backend E2E Tests - Openshift
     script:


### PR DESCRIPTION
Honestly not sure where this should go. We need the images to be available, so I figure after the smoke tests. This seems expedient but perhaps not ideal as it ends up kind of buried in the test job.

There might be a pure-docker way to do this without kubernetes, as all we need is for the docker client in the scanner to be able to unpack the images, but I couldn't sort it out quickly. If we did this in a separate minikube job, then we'd have to write something to wait for the helm install to be done downloading all the images needed.