### PR TITLE
Support different frontend image for e2e test

### DIFF
--- a/enterprise-suite/tests/smoketest_minikube.sh
+++ b/enterprise-suite/tests/smoketest_minikube.sh
@@ -22,20 +22,20 @@ function diagnostics() {
 }
 
 function setup() {
-	kubectl create namespace ${NAMESPACE}
-	kubectl create namespace ${TILLER_NAMESPACE}
-	kubectl create serviceaccount --namespace ${TILLER_NAMESPACE} tiller
-	kubectl create clusterrolebinding ${TILLER_NAMESPACE}:tiller --clusterrole=cluster-admin \
-	    --serviceaccount=${TILLER_NAMESPACE}:tiller
-	helm init --wait --service-account tiller --upgrade --tiller-namespace=${TILLER_NAMESPACE}
+    kubectl create namespace ${NAMESPACE}
+    kubectl create namespace ${TILLER_NAMESPACE}
+    kubectl create serviceaccount --namespace ${TILLER_NAMESPACE} tiller
+    kubectl create clusterrolebinding ${TILLER_NAMESPACE}:tiller --clusterrole=cluster-admin \
+        --serviceaccount=${TILLER_NAMESPACE}:tiller
+    helm init --wait --service-account tiller --upgrade --tiller-namespace=${TILLER_NAMESPACE}
 
-	kubectl config set-context minikube --namespace=${NAMESPACE}
+    kubectl config set-context minikube --namespace=${NAMESPACE}
 
-	${script_dir}/../scripts/lbc.py install --namespace=${NAMESPACE} --local-chart=${script_dir}/.. -- \
-		--set podUID=10001,usePersistentVolumes=true,prometheusDomain=console-backend-e2e.io \
-		--set exposeServices=NodePort,esConsoleExposePort=30080 \
-    ${ES_CONSOLE_VERSION+--set esConsoleVersion=${ES_CONSOLE_VERSION}} \
-		--wait
+    ${script_dir}/../scripts/lbc.py install --namespace=${NAMESPACE} --local-chart=${script_dir}/.. -- \
+        --set podUID=10001,usePersistentVolumes=true,prometheusDomain=console-backend-e2e.io \
+        --set exposeServices=NodePort,esConsoleExposePort=30080 \
+        ${ES_CONSOLE_VERSION+--set esConsoleVersion=${ES_CONSOLE_VERSION}} \
+        --wait
 }
 
 function cleanup() {

--- a/enterprise-suite/tests/smoketest_minikube.sh
+++ b/enterprise-suite/tests/smoketest_minikube.sh
@@ -23,7 +23,7 @@ function diagnostics() {
 
 function setup() {
 	local es_console_version; es_console_version=''
-	[[ -n $ES_CONSOLE_VERSION ]] && es_console_version="esConsoleVersion=$ES_CONSOLE_VERSION,"
+	[[ -n "${ES_CONSOLE_VERSION:-}" ]] && es_console_version=",esConsoleVersion=${ES_CONSOLE_VERSION}"
 	kubectl create namespace ${NAMESPACE}
 	kubectl create namespace ${TILLER_NAMESPACE}
 	kubectl create serviceaccount --namespace ${TILLER_NAMESPACE} tiller
@@ -35,7 +35,7 @@ function setup() {
 
 	${script_dir}/../scripts/lbc.py install --namespace=${NAMESPACE} --local-chart=${script_dir}/.. -- \
 		--set podUID=10001,usePersistentVolumes=true,prometheusDomain=console-backend-e2e.io \
-		--set exposeServices=NodePort,${es_console_version}esConsoleExposePort=30080 \
+		--set exposeServices=NodePort,esConsoleExposePort=30080${es_console_version} \
 		--wait
 }
 

--- a/enterprise-suite/tests/smoketest_minikube.sh
+++ b/enterprise-suite/tests/smoketest_minikube.sh
@@ -22,8 +22,6 @@ function diagnostics() {
 }
 
 function setup() {
-	local es_console_version=
-	[[ -n "${ES_CONSOLE_VERSION:-}" ]] && es_console_version="--set esConsoleVersion=${ES_CONSOLE_VERSION}"
 	kubectl create namespace ${NAMESPACE}
 	kubectl create namespace ${TILLER_NAMESPACE}
 	kubectl create serviceaccount --namespace ${TILLER_NAMESPACE} tiller
@@ -36,7 +34,7 @@ function setup() {
 	${script_dir}/../scripts/lbc.py install --namespace=${NAMESPACE} --local-chart=${script_dir}/.. -- \
 		--set podUID=10001,usePersistentVolumes=true,prometheusDomain=console-backend-e2e.io \
 		--set exposeServices=NodePort,esConsoleExposePort=30080 \
-    ${es_console_version} \
+    ${ES_CONSOLE_VERSION+--set esConsoleVersion=${ES_CONSOLE_VERSION}} \
 		--wait
 }
 

--- a/enterprise-suite/tests/smoketest_minikube.sh
+++ b/enterprise-suite/tests/smoketest_minikube.sh
@@ -22,8 +22,8 @@ function diagnostics() {
 }
 
 function setup() {
-	local es_console_version; es_console_version=''
-	[[ -n "${ES_CONSOLE_VERSION:-}" ]] && es_console_version=",esConsoleVersion=${ES_CONSOLE_VERSION}"
+	local es_console_version=
+	[[ -n "${ES_CONSOLE_VERSION:-}" ]] && es_console_version="--set esConsoleVersion=${ES_CONSOLE_VERSION}"
 	kubectl create namespace ${NAMESPACE}
 	kubectl create namespace ${TILLER_NAMESPACE}
 	kubectl create serviceaccount --namespace ${TILLER_NAMESPACE} tiller
@@ -35,7 +35,8 @@ function setup() {
 
 	${script_dir}/../scripts/lbc.py install --namespace=${NAMESPACE} --local-chart=${script_dir}/.. -- \
 		--set podUID=10001,usePersistentVolumes=true,prometheusDomain=console-backend-e2e.io \
-		--set exposeServices=NodePort,esConsoleExposePort=30080${es_console_version} \
+		--set exposeServices=NodePort,esConsoleExposePort=30080 \
+    ${es_console_version} \
 		--wait
 }
 

--- a/enterprise-suite/tests/smoketest_minikube.sh
+++ b/enterprise-suite/tests/smoketest_minikube.sh
@@ -22,6 +22,8 @@ function diagnostics() {
 }
 
 function setup() {
+	local es_console_version; es_console_version=''
+	[[ -n $ES_CONSOLE_VERSION ]] && es_console_version="esConsoleVersion=$ES_CONSOLE_VERSION,"
 	kubectl create namespace ${NAMESPACE}
 	kubectl create namespace ${TILLER_NAMESPACE}
 	kubectl create serviceaccount --namespace ${TILLER_NAMESPACE} tiller
@@ -33,7 +35,7 @@ function setup() {
 
 	${script_dir}/../scripts/lbc.py install --namespace=${NAMESPACE} --local-chart=${script_dir}/.. -- \
 		--set podUID=10001,usePersistentVolumes=true,prometheusDomain=console-backend-e2e.io \
-		--set exposeServices=NodePort,esConsoleExposePort=30080 \
+		--set exposeServices=NodePort,${es_console_version}esConsoleExposePort=30080 \
 		--wait
 }
 


### PR DESCRIPTION
Support different frontend image for e2e test. 
For example, run 
```
ES_CONSOLE_VERSION=e2e make frontend-tests
```

The purpose of this PR is to use the same e2e setup cross repo es-console-spa and helm-charts

