### PR TITLE
update prometheus to v2.7.0-rc.0

### DIFF
--- a/enterprise-suite/es-monitor-api/default-monitors.json
+++ b/enterprise-suite/es-monitor-api/default-monitors.json
@@ -210,7 +210,7 @@
             }
           },
           "summary": "Prometheus target over limit",
-          "description": "Prometheus target at {{labels.instance}} has too many metrics"
+          "description": "Prometheus target at {{$labels.instance}} has too many metrics"
         }
       },
       "prometheus_tsdb_reloads_failures": {
@@ -349,7 +349,7 @@
             }
           },
           "summary": "Zookeeper open file descriptor growth",
-          "description": "Zookeeper open file descriptors in ${{labels.es_workload}} is not normal in ${{labels.instance}}"
+          "description": "Zookeeper open file descriptors in {{$labels.es_workload}} is not normal in {{$labels.instance}}"
         }
       },
       "cassandra_write_latency": {
@@ -403,7 +403,7 @@
             }
           },
           "summary": "Redis key space miss ratio growth",
-          "description": "Observing shifts in Redis key space ratio on ${{labels.es_workload}} in ${{labels.instance}}"
+          "description": "Observing shifts in Redis key space ratio on {{$labels.es_workload}} in {{$labels.instance}}"
         }
       },
       "redis_evictions": {
@@ -439,7 +439,7 @@
             }
           },
           "summary": "Redis command processed",
-          "description": "Redis commands processed on {{$labels.es_workload}} is not normal in ${{labels.instance}}"
+          "description": "Redis commands processed on {{$labels.es_workload}} is not normal in {{$labels.instance}}"
         }
       },
       "redis_connections": {
@@ -475,7 +475,7 @@
             }
           },
           "summary": "Kafka incoming message rate is not normal",
-          "description": "Kafka incoming message rate on ${{labels.es_workload}} is not normal for topic ${{labels.topic}}"
+          "description": "Kafka incoming message rate on {{$labels.es_workload}} is not normal for topic {{$labels.topic}}"
         }
       },
       "kafka_offline_partition": {
@@ -492,7 +492,7 @@
             }
           },
           "summary": "Kafka offline partition is not zero",
-          "description": "Kafka offline partition is high on ${{labels.es_workload}} in ${{labels.instance}}"
+          "description": "Kafka offline partition is high on {{$labels.es_workload}} in {{$labels.instance}}"
         }
       },
       "kafka_under_replicated_partitions": {
@@ -509,7 +509,7 @@
             }
           },
           "summary": "Kafka under replicated partitions is up",
-          "description": "Kafka under replicated partitions is high on ${{labels.es_workload}} in ${{labels.instance}}"
+          "description": "Kafka under replicated partitions is high on {{$labels.es_workload}} in {{$labels.instance}}"
         }
       },
       "memcached_miss_ratio": {

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -8,7 +8,7 @@ esMonitorVersion: v1.0.5
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-grafana
 esGrafanaVersion: v0.1.5
 # prom/prometheus
-prometheusVersion: v2.2.1
+prometheusVersion: v2.7.0-rc.0
 # prom/alertmanager
 alertManagerVersion: v0.15.1
 # jimmidyson/configmap-reload


### PR DESCRIPTION
* fix syntax errors in monitor description templates
* upgrade prometheus to rc with subqueries

subqueries allow us to eliminate promjs for backtesting monitors, now we can do it all in a server query

https://docs.google.com/document/d/1P_G87zN88YvmMr4iwLWygChMTZhai1L7S_c0awu1CAE/edit