### PR TITLE
Rename createPersistentVolumes to managePersistentVolumes

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -404,10 +404,10 @@ def install(creds_file):
                 .format(args.helm_name, chart_ref, version_arg,
                         creds_arg, helm_args))
         else:
-            createPVs = len(filter(lambda x: 'createPersistentVolumes=false' in x, sys.argv)) == 0
+            createPVs = len(filter(lambda x: 'managePersistentVolumes=false' in x, sys.argv)) == 0
             if createPVs and are_pvcs_created(args.namespace):
                 printerr('info: Found existing PVCs from a previous console installation.')
-                printerr('info: Please remove them with `kubectl delete pvc`, or pass --set createPersistentVolumes=false.')
+                printerr('info: Please remove them with `kubectl delete pvc`, or pass --set managePersistentVolumes=false.')
                 printerr('info: Otherwise, the install may fail.')
 
             execute('helm install {} --name {} --namespace {} {} {} {}'

--- a/enterprise-suite/templates/alertmanager-deployment.yaml
+++ b/enterprise-suite/templates/alertmanager-deployment.yaml
@@ -89,7 +89,7 @@ spec:
           configMap:
             name: {{ .Values.alertManagerConfigMap }}
         - name: data-volume
-          {{ if or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes) }}
+          {{ if .Values.usePersistentVolumes }}
           persistentVolumeClaim:
             claimName: alertmanager-storage
           {{ else }}

--- a/enterprise-suite/templates/alertmanager-pvc.yaml
+++ b/enterprise-suite/templates/alertmanager-pvc.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.createAlertManager and .Values.managePersistentVolumes }}
+{{ if (and .Values.createAlertManager .Values.managePersistentVolumes) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/enterprise-suite/templates/alertmanager-pvc.yaml
+++ b/enterprise-suite/templates/alertmanager-pvc.yaml
@@ -1,6 +1,4 @@
-{{- $shouldCreatePVCs := and (or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes)) (.Values.createPersistentVolumes) }}
-{{ if .Values.createAlertManager }}
-{{ if $shouldCreatePVCs }}
+{{ if .Values.createAlertManager and .Values.managePersistentVolumes }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -14,5 +12,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.alertmanagerVolumeSize }}
-{{ end }}
 {{ end }}

--- a/enterprise-suite/templates/es-grafana-deployment.yaml
+++ b/enterprise-suite/templates/es-grafana-deployment.yaml
@@ -80,7 +80,7 @@ spec:
         configMap:
           name: grafana-datasource-cm
       - name: grafana-data
-        {{ if or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes) }}
+        {{ if .Values.usePersistentVolumes }}
         persistentVolumeClaim:
           claimName: es-grafana-storage
         {{ else }}

--- a/enterprise-suite/templates/es-grafana-pvc.yaml
+++ b/enterprise-suite/templates/es-grafana-pvc.yaml
@@ -1,5 +1,4 @@
-{{- $shouldCreatePVCs := and (or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes)) (.Values.createPersistentVolumes) }}
-{{ if $shouldCreatePVCs }}
+{{ if .Values.managePersistentVolumes }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/enterprise-suite/templates/prometheus-deployment.yaml
+++ b/enterprise-suite/templates/prometheus-deployment.yaml
@@ -173,7 +173,7 @@ spec:
           configMap:
             name: es-monitor-api
         - name: prometheus-data-volume
-          {{ if or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes) }}
+          {{ if .Values.usePersistentVolumes }}
           persistentVolumeClaim:
             claimName: prometheus-storage
           {{ else }}

--- a/enterprise-suite/templates/prometheus-pvc.yaml
+++ b/enterprise-suite/templates/prometheus-pvc.yaml
@@ -1,5 +1,4 @@
-{{- $shouldCreatePVCs := and (or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes)) (.Values.createPersistentVolumes) }}
-{{ if $shouldCreatePVCs }}
+{{ if .Values.managePersistentVolumes }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -108,12 +108,11 @@ prometheusMemoryRequest: 250Mi
 #################################################
 # Persistent Volumes
 #
-# Deprecated value - set to false to disable emptyDir and use persistent volumes. Prefer `usePersistentVolumes`.
-useEmptyDirVolumes: true
 # Set to true to use persistent volumes, otherwise emptyDir volumes are used.
 usePersistentVolumes: false
-# If true, the chart creates persistent volumes using PVCs. Set to false to reuse previously created persistent volumes.
-createPersistentVolumes: true
+# If true, the chart manages persistent volumes by creating PVCs. Set to false to not manage PVCs at all.
+# Warning: If you "unmanage" PVCs that helm is managing by setting this to false, helm will delete those PVCs.
+managePersistentVolumes: true
 # Default StorageClass to use for persistent volumes
 defaultStorageClass: standard
 # Prometheus volume size - used for storing metrics data.


### PR DESCRIPTION
So it's meaning is hopefully clearer, to avoid accidental data loss.

Also a few other changes to prevent accidental data loss:
- Remove convoluted logic around whether to create the PVC resource.
Instead, just use `managePersistentVolumes` as the flag. So it's very
clear there is only one way to delete PVCs (set managePersistentVolumes
to false).
- Remove deprecated parameter `useEmptyDirVolumes`. Instead use
`usePersistentVolumes` (which defaults to false).

For https://github.com/lightbend/es-backend/issues/554