### PR TITLE
Use cluster DNS directly in nginx config

### DIFF
--- a/enterprise-suite/templates/es-console-configmap.yaml
+++ b/enterprise-suite/templates/es-console-configmap.yaml
@@ -18,12 +18,12 @@ data:
 
       # use external resolver to lookup backends, cache for 30 seconds
 
-      resolver 127.0.0.1:5353 ipv6=off valid=30s;
+      resolver $KUBE_RESOLVER ipv6=off valid=30s;
 
-      set $prometheus "prometheus-server";
-      set $monitorapi "es-monitor-api";
-      set $grafana "grafana-server";
-      set $alertmanager {{ splitList "," .Values.alertManagers | first | quote }};
+      set $prometheus "prometheus-server.$KUBE_DOMAIN";
+      set $monitorapi "es-monitor-api.$KUBE_DOMAIN";
+      set $grafana "grafana-server.$KUBE_DOMAIN";
+      set $alertmanager {{ print (splitList "," .Values.alertManagers | first) `.$KUBE_DOMAIN:9093` | quote }};
 
       # nginx config primer:
       # location ~ (regex.*)(matchers.*) { regex matchers become $1 and $2 in the block }

--- a/enterprise-suite/templates/es-console-configmap.yaml
+++ b/enterprise-suite/templates/es-console-configmap.yaml
@@ -23,7 +23,7 @@ data:
       set $prometheus "prometheus-server.$KUBE_DOMAIN";
       set $monitorapi "es-monitor-api.$KUBE_DOMAIN";
       set $grafana "grafana-server.$KUBE_DOMAIN";
-      set $alertmanager {{ print (splitList "," .Values.alertManagers | first) `.$KUBE_DOMAIN:9093` | quote }};
+      set $alertmanager {{ splitList "," .Values.alertManagers | first | quote }};
 
       # nginx config primer:
       # location ~ (regex.*)(matchers.*) { regex matchers become $1 and $2 in the block }

--- a/enterprise-suite/templates/es-console-configmap.yaml
+++ b/enterprise-suite/templates/es-console-configmap.yaml
@@ -20,9 +20,9 @@ data:
 
       resolver $KUBE_RESOLVER ipv6=off valid=30s;
 
-      set $prometheus "prometheus-server.$KUBE_DOMAIN";
-      set $monitorapi "es-monitor-api.$KUBE_DOMAIN";
-      set $grafana "grafana-server.$KUBE_DOMAIN";
+      set $prometheus "prometheus-server.$KUBE_CONSOLE_DOMAIN";
+      set $monitorapi "es-monitor-api.$KUBE_CONSOLE_DOMAIN";
+      set $grafana "grafana-server.$KUBE_CONSOLE_DOMAIN";
       set $alertmanager {{ splitList "," .Values.alertManagers | first | quote }};
 
       # nginx config primer:

--- a/enterprise-suite/templates/es-console-deployment.yaml
+++ b/enterprise-suite/templates/es-console-deployment.yaml
@@ -28,11 +28,13 @@ spec:
         - -c
         args:
         - >-
-          apk add gettext &&
           export KUBE_RESOLVER=$(awk '$1 == "nameserver" { print $2 }' /etc/resolv.conf) &&
           export KUBE_CONSOLE_DOMAIN=$(awk '$1 == "search" { print $2 }' /etc/resolv.conf) &&
           echo "resolver=$KUBE_RESOLVER console_domain=$KUBE_CONSOLE_DOMAIN" &&
-          cat /template/default.conf | envsubst '$KUBE_RESOLVER $KUBE_CONSOLE_DOMAIN' > /etc/nginx/conf.d/default.conf &&
+          cat /template/default.conf
+          | sed "s/\$KUBE_RESOLVER/$KUBE_RESOLVER/g"
+          | sed "s/\$KUBE_CONSOLE_DOMAIN/$KUBE_CONSOLE_DOMAIN/g"
+          > /etc/nginx/conf.d/default.conf &&
           echo "done templating /etc/nginx/conf.d/default.conf"
 
         volumeMounts:
@@ -40,13 +42,6 @@ spec:
             mountPath: /etc/nginx/conf.d
           - name: nginx-template
             mountPath: /template
-
-        {{ if .Values.podUID }}
-        # Run init container as root so it can install gettext. This should be okay since it's a transient one-off
-        # container without any external access.
-        securityContext:
-          runAsUser: 0
-        {{ end }}
 
       containers:
       - name: es-console

--- a/enterprise-suite/templates/es-console-deployment.yaml
+++ b/enterprise-suite/templates/es-console-deployment.yaml
@@ -41,6 +41,14 @@ spec:
           - name: nginx-template
             mountPath: /template
 
+        {{ if .Values.podUID }}
+        # Run init container as root so it can install gettext. This should be okay since it's a transient one-off
+        # container without any external access.
+        securityContext:
+          runAsUser: 0
+        {{ end }}
+
+
       containers:
       - name: es-console
         image: {{ tpl .Values.esConsoleImage . }}:{{ .Values.esConsoleVersion }}

--- a/enterprise-suite/templates/es-console-deployment.yaml
+++ b/enterprise-suite/templates/es-console-deployment.yaml
@@ -16,14 +16,32 @@ spec:
       imagePullSecrets:
       - name: commercial-credentials
 
-      containers:
-      - name: dnsmasq
-        image: {{ .Values.goDnsmasqImage }}:{{ .Values.goDnsmasqVersion }}
+      initContainers:
+      - name: setup-nginx-dns
+        image: {{ .Values.alpineImage }}:{{ .Values.alpineVersion }}
+        resources:
+          requests:
+            cpu: {{ default .Values.defaultCPURequest }}
+            memory: {{ default .Values.defaultMemoryRequest }}
+        command:
+        - /bin/sh
+        - -c
         args:
-          - --listen
-          - "127.0.0.1:5353"
-          - --verbose
-          - --enable-search
+        - >-
+          apk add gettext &&
+          export KUBE_RESOLVER=$(awk '$1 == "nameserver" { print $2 }' /etc/resolv.conf) &&
+          export KUBE_DOMAIN=$(awk '$1 == "search" { print $2 }' /etc/resolv.conf) &&
+          echo "resolver=$KUBE_RESOLVER domain=$KUBE_DOMAIN" &&
+          cat /template/default.conf | envsubst '$KUBE_RESOLVER $KUBE_DOMAIN' > /etc/nginx/conf.d/default.conf &&
+          echo "done templating /etc/nginx/conf.d/default.conf"
+
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/nginx/conf.d
+          - name: nginx-template
+            mountPath: /template
+
+      containers:
       - name: es-console
         image: {{ tpl .Values.esConsoleImage . }}:{{ .Values.esConsoleVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -39,5 +57,7 @@ spec:
 
       volumes:
       - name: config-volume
+        emptyDir: {}
+      - name: nginx-template
         configMap:
           name: es-console

--- a/enterprise-suite/templates/es-console-deployment.yaml
+++ b/enterprise-suite/templates/es-console-deployment.yaml
@@ -30,9 +30,9 @@ spec:
         - >-
           apk add gettext &&
           export KUBE_RESOLVER=$(awk '$1 == "nameserver" { print $2 }' /etc/resolv.conf) &&
-          export KUBE_DOMAIN=$(awk '$1 == "search" { print $2 }' /etc/resolv.conf) &&
-          echo "resolver=$KUBE_RESOLVER domain=$KUBE_DOMAIN" &&
-          cat /template/default.conf | envsubst '$KUBE_RESOLVER $KUBE_DOMAIN' > /etc/nginx/conf.d/default.conf &&
+          export KUBE_CONSOLE_DOMAIN=$(awk '$1 == "search" { print $2 }' /etc/resolv.conf) &&
+          echo "resolver=$KUBE_RESOLVER console_domain=$KUBE_CONSOLE_DOMAIN" &&
+          cat /template/default.conf | envsubst '$KUBE_RESOLVER $KUBE_CONSOLE_DOMAIN' > /etc/nginx/conf.d/default.conf &&
           echo "done templating /etc/nginx/conf.d/default.conf"
 
         volumeMounts:

--- a/enterprise-suite/templates/es-console-deployment.yaml
+++ b/enterprise-suite/templates/es-console-deployment.yaml
@@ -48,7 +48,6 @@ spec:
           runAsUser: 0
         {{ end }}
 
-
       containers:
       - name: es-console
         image: {{ tpl .Values.esConsoleImage . }}:{{ .Values.esConsoleVersion }}

--- a/enterprise-suite/tests/smoketest
+++ b/enterprise-suite/tests/smoketest
@@ -18,6 +18,11 @@ function log_debug() {
     echo "Deployment details:"
     echo
     for pod in $pods; do
+        if [[ "$pod" =~ ^tiller-deploy.*$ ]]; then
+            # tiller is too noisy - skip it
+            # if tiller has an issue, it should have failed in setup
+            continue
+        fi
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         echo "Describe $pod:"
         echo

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -71,7 +71,7 @@ imageCredentials:
 createAlertManager: true
 
 # Comma separated list of alertmanager addresses (can be k8s local DNS service names)
-alertManagers: alertmanager.$KUBE_DOMAIN:9093
+alertManagers: alertmanager.$KUBE_CONSOLE_DOMAIN:9093
 
 # Alertmanager ConfigMap. Set to the name of a ConfigMap, with a file `alertmanager.yml`.
 alertManagerConfigMap: alertmanager-default

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -15,10 +15,6 @@ alertManagerVersion: v0.15.1
 configMapReloadVersion: v0.2.2
 # gcr.io/google_containers/kube-state-metrics
 kubeStateMetricsVersion: v1.2.0
-# prom/node-exporter
-nodeExporterVersion: v0.15.2
-# janeczku/go-dnsmasq
-goDnsmasqVersion: release-1.0.7
 # alpine
 alpineVersion: 3.8
 # busybox
@@ -41,10 +37,6 @@ alertManagerImage: prom/alertmanager
 configMapReloadImage: jimmidyson/configmap-reload
 # kube-state-metrics image
 kubeStateMetricsImage: gcr.io/google_containers/kube-state-metrics
-# node-exporter image
-nodeExporterImage: prom/node-exporter
-# go-dnsmasq image
-goDnsmasqImage: janeczku/go-dnsmasq
 # alpine image
 alpineImage: alpine
 # busybox image
@@ -79,7 +71,7 @@ imageCredentials:
 createAlertManager: true
 
 # Comma separated list of alertmanager addresses (can be k8s local DNS service names)
-alertManagers: alertmanager:9093
+alertManagers: alertmanager
 
 # Alertmanager ConfigMap. Set to the name of a ConfigMap, with a file `alertmanager.yml`.
 alertManagerConfigMap: alertmanager-default

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -71,7 +71,7 @@ imageCredentials:
 createAlertManager: true
 
 # Comma separated list of alertmanager addresses (can be k8s local DNS service names)
-alertManagers: alertmanager
+alertManagers: alertmanager.$KUBE_DOMAIN:9093
 
 # Alertmanager ConfigMap. Set to the name of a ConfigMap, with a file `alertmanager.yml`.
 alertManagerConfigMap: alertmanager-default


### PR DESCRIPTION
Instead of using go-dnsmasq, just parse /etc/resolv.conf directly and
insert the needed values into nginx.conf.

This avoids the need for an intermediate container, and relies on the
stable interface of /etc/resolv.conf. Note there is currently no way to
query k8s for this information other than checking resolv.conf.

For https://github.com/lightbend/es-backend/issues/541