### PR TITLE
Fix alertmanager / prometheus integration

### DIFF
--- a/enterprise-suite/templates/es-console-configmap.yaml
+++ b/enterprise-suite/templates/es-console-configmap.yaml
@@ -17,13 +17,17 @@ data:
         "X-XSS-Protection: 1";
 
       # use external resolver to lookup backends, cache for 30 seconds
-
       resolver $KUBE_RESOLVER ipv6=off valid=30s;
 
       set $prometheus "prometheus-server.$KUBE_CONSOLE_DOMAIN";
       set $monitorapi "es-monitor-api.$KUBE_CONSOLE_DOMAIN";
       set $grafana "grafana-server.$KUBE_CONSOLE_DOMAIN";
+      {{ if .Values.alertManagers }}
       set $alertmanager {{ splitList "," .Values.alertManagers | first | quote }};
+      {{ else }}
+      # Use bundled alertmanager.
+      set $alertmanager "alertmanager.$KUBE_CONSOLE_DOMAIN:9093";
+      {{ end }}
 
       # nginx config primer:
       # location ~ (regex.*)(matchers.*) { regex matchers become $1 and $2 in the block }

--- a/enterprise-suite/templates/prometheus-deployment.yaml
+++ b/enterprise-suite/templates/prometheus-deployment.yaml
@@ -84,7 +84,7 @@ spec:
             - --defaultMonitorsFile=/etc/es-monitor-api/default-monitors.json
             - --prometheusTemplate=/etc/es-monitor-api/prometheus.yml
             - --prometheusDomain={{ .Values.prometheusDomain }}
-            - --alertmanagers={{ .Values.alertManagers }}
+            - --alertmanagers={{ default "alertmanager:9093" .Values.alertManagers }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -70,8 +70,9 @@ imageCredentials:
 # If true, an alertmanager will be deployed. Set to false and modify `alertManagers` list to use existing alertmanager(s).
 createAlertManager: true
 
-# Comma separated list of alertmanager addresses (can be k8s local DNS service names)
-alertManagers: alertmanager.$KUBE_CONSOLE_DOMAIN:9093
+# Comma separated list of alertmanager addresses to use. Set this if you want to integrate with an existing alertmanager.
+# Leave blank to use the bundled alertmanager.
+alertManagers:
 
 # Alertmanager ConfigMap. Set to the name of a ConfigMap, with a file `alertmanager.yml`.
 alertManagerConfigMap: alertmanager-default


### PR DESCRIPTION
This fixes the integration in the direct-DNS solution being used in nginx at the moment.

For https://github.com/lightbend/es-backend/issues/541