### PR TITLE
Use lightbend forked go-dnsmasq

### DIFF
--- a/enterprise-suite/templates/es-console-configmap.yaml
+++ b/enterprise-suite/templates/es-console-configmap.yaml
@@ -18,11 +18,11 @@ data:
 
       # use external resolver to lookup backends, cache for 30 seconds
 
-      resolver $KUBE_RESOLVER ipv6=off valid=30s;
+      resolver 127.0.0.1:5353 ipv6=off valid=30s;
 
-      set $prometheus "prometheus-server.$KUBE_CONSOLE_DOMAIN";
-      set $monitorapi "es-monitor-api.$KUBE_CONSOLE_DOMAIN";
-      set $grafana "grafana-server.$KUBE_CONSOLE_DOMAIN";
+      set $prometheus "prometheus-server";
+      set $monitorapi "es-monitor-api";
+      set $grafana "grafana-server";
       set $alertmanager {{ splitList "," .Values.alertManagers | first | quote }};
 
       # nginx config primer:

--- a/enterprise-suite/templates/es-console-deployment.yaml
+++ b/enterprise-suite/templates/es-console-deployment.yaml
@@ -16,34 +16,14 @@ spec:
       imagePullSecrets:
       - name: commercial-credentials
 
-      initContainers:
-      - name: setup-nginx-dns
-        image: {{ .Values.alpineImage }}:{{ .Values.alpineVersion }}
-        resources:
-          requests:
-            cpu: {{ default .Values.defaultCPURequest }}
-            memory: {{ default .Values.defaultMemoryRequest }}
-        command:
-        - /bin/sh
-        - -c
-        args:
-        - >-
-          export KUBE_RESOLVER=$(awk '$1 == "nameserver" { print $2 }' /etc/resolv.conf) &&
-          export KUBE_CONSOLE_DOMAIN=$(awk '$1 == "search" { print $2 }' /etc/resolv.conf) &&
-          echo "resolver=$KUBE_RESOLVER console_domain=$KUBE_CONSOLE_DOMAIN" &&
-          cat /template/default.conf
-          | sed "s/\$KUBE_RESOLVER/$KUBE_RESOLVER/g"
-          | sed "s/\$KUBE_CONSOLE_DOMAIN/$KUBE_CONSOLE_DOMAIN/g"
-          > /etc/nginx/conf.d/default.conf &&
-          echo "done templating /etc/nginx/conf.d/default.conf"
-
-        volumeMounts:
-          - name: config-volume
-            mountPath: /etc/nginx/conf.d
-          - name: nginx-template
-            mountPath: /template
-
       containers:
+      - name: dnsmasq
+        image: {{ .Values.goDnsmasqImage }}:{{ .Values.goDnsmasqVersion }}
+        args:
+          - --listen
+          - "127.0.0.1:5353"
+          - --verbose
+          - --enable-search
       - name: es-console
         image: {{ tpl .Values.esConsoleImage . }}:{{ .Values.esConsoleVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -59,7 +39,5 @@ spec:
 
       volumes:
       - name: config-volume
-        emptyDir: {}
-      - name: nginx-template
         configMap:
           name: es-console

--- a/enterprise-suite/tests/smoketest
+++ b/enterprise-suite/tests/smoketest
@@ -18,11 +18,6 @@ function log_debug() {
     echo "Deployment details:"
     echo
     for pod in $pods; do
-        if [[ "$pod" =~ ^tiller-deploy.*$ ]]; then
-            # tiller is too noisy - skip it
-            # if tiller has an issue, it should have failed in setup
-            continue
-        fi
         echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         echo "Describe $pod:"
         echo

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -15,6 +15,10 @@ alertManagerVersion: v0.15.1
 configMapReloadVersion: v0.2.2
 # gcr.io/google_containers/kube-state-metrics
 kubeStateMetricsVersion: v1.2.0
+# prom/node-exporter
+nodeExporterVersion: v0.15.2
+# janeczku/go-dnsmasq
+goDnsmasqVersion: release-1.0.7
 # alpine
 alpineVersion: 3.8
 # busybox
@@ -37,6 +41,10 @@ alertManagerImage: prom/alertmanager
 configMapReloadImage: jimmidyson/configmap-reload
 # kube-state-metrics image
 kubeStateMetricsImage: gcr.io/google_containers/kube-state-metrics
+# node-exporter image
+nodeExporterImage: prom/node-exporter
+# go-dnsmasq image
+goDnsmasqImage: janeczku/go-dnsmasq
 # alpine image
 alpineImage: alpine
 # busybox image
@@ -71,7 +79,7 @@ imageCredentials:
 createAlertManager: true
 
 # Comma separated list of alertmanager addresses (can be k8s local DNS service names)
-alertManagers: alertmanager.$KUBE_CONSOLE_DOMAIN:9093
+alertManagers: alertmanager:9093
 
 # Alertmanager ConfigMap. Set to the name of a ConfigMap, with a file `alertmanager.yml`.
 alertManagerConfigMap: alertmanager-default

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -15,7 +15,7 @@ alertManagerVersion: v0.15.1
 configMapReloadVersion: v0.2.2
 # gcr.io/google_containers/kube-state-metrics
 kubeStateMetricsVersion: v1.2.0
-# janeczku/go-dnsmasq
+# lightbend/go-dnsmasq
 goDnsmasqVersion: v0.1.7-1
 # alpine
 alpineVersion: 3.8

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -15,10 +15,8 @@ alertManagerVersion: v0.15.1
 configMapReloadVersion: v0.2.2
 # gcr.io/google_containers/kube-state-metrics
 kubeStateMetricsVersion: v1.2.0
-# prom/node-exporter
-nodeExporterVersion: v0.15.2
 # janeczku/go-dnsmasq
-goDnsmasqVersion: release-1.0.7
+goDnsmasqVersion: v0.1.7-1
 # alpine
 alpineVersion: 3.8
 # busybox
@@ -41,10 +39,8 @@ alertManagerImage: prom/alertmanager
 configMapReloadImage: jimmidyson/configmap-reload
 # kube-state-metrics image
 kubeStateMetricsImage: gcr.io/google_containers/kube-state-metrics
-# node-exporter image
-nodeExporterImage: prom/node-exporter
 # go-dnsmasq image
-goDnsmasqImage: janeczku/go-dnsmasq
+goDnsmasqImage: lightbend-docker-registry.bintray.io/lightbend/go-dnsmasq
 # alpine image
 alpineImage: alpine
 # busybox image


### PR DESCRIPTION
This version of go-dnsmasq (https://github.com/lightbend/go-dnsmasq) updates the alpine
image and golang dependencies to fix security vulnerabilities.

Depends on https://github.com/lightbend/go-dnsmasq/pull/1

For https://github.com/lightbend/es-backend/issues/541