### PR TITLE
Add smoke_alert to test generation and issuing of alerts

### DIFF
--- a/enterprise-suite/tests/prometheus_common
+++ b/enterprise-suite/tests/prometheus_common
@@ -1,0 +1,85 @@
+# functions common to smoke_prometheus and smoke_alert
+
+deployments_up() {
+  results=$( kubectl get pods -n $NAMESPACE --no-headers | awk '{print $3;}' | grep -v Running | wc -l )
+  [[ results -eq 0 ]]
+}
+
+#
+# prometheus fetchers
+#
+
+ES_CONSOLE=$( busy_wait nodeport )
+PROM="$ES_CONSOLE/service/prometheus"
+ES_MONITOR_API="$ES_CONSOLE/service/es-monitor-api"
+
+prom_query() {
+  curl -fsG "$PROM/api/v1/query" --data-urlencode "query=$*"
+}
+
+prom_has_data() {
+  test_prom_has_data () {
+    results=$( prom_query "$@" | jq '.data.result | length' )
+    ! [[ results -eq 0 ]]
+  }
+  timeout test_prom_has_data "$@"
+  T $? timeseries: "$*"
+}
+
+prom_has_no_data() {
+  test_prom_has_data () {
+    results=$( prom_query "$@" | jq '.data.result | length' )
+    [[ results -eq 0 ]]
+  }
+  timeout test_prom_has_data "$@"
+  T $? timeseries: "$*"
+}
+
+model_exists() {
+  results=$( prom_query "model{name=\"$1\"}" | jq '.data.result | length' )
+  ! [[ results -eq 0 ]]
+}
+
+#
+# log fetchers
+#
+
+kube_state_metrics_logs() {
+  kubectl logs --tail=100 --namespace=${NAMESPACE} -l app=prometheus,component=kube-state-metrics
+}
+prom_logs() {
+  kubectl logs --tail=100 --namespace=${NAMESPACE} -l app=prometheus,component=server -c prometheus-server
+}
+
+
+# this might be useful? dunno
+# prom_interval() {
+#   prom_query "prometheus_target_interval_length_seconds" |
+#    jq -r '.data.result[0].metric.interval' |
+#    sed -e 's/[^0-9.]//g'
+# }
+# PROM_INTERVAL=$( busy_wait prom_interval )
+
+# prom_three_scrapes  waits until we've seen three scrapes of given metric
+#  two scrapes is needed to compute a rate, then three is needed for rate of rate
+
+prom_three_scrapes() {
+  results=$( prom_query "count_over_time($1[10m]) > 2" | jq '.data.result | length' )
+  ! [[ results -eq 0 ]]
+}
+
+#
+# prometheus
+#
+
+prom_scrapes() {
+  prom_query "sum(up)" |
+   jq -r '.data.result[0].value[1]'
+}
+
+# app via 'Pod' service discovery
+# $1 is query to find app instances
+app_data() {
+  results=$( prom_query "$1" | jq '.data.result | length' )
+  ! [[ results -eq 0 ]]
+}

--- a/enterprise-suite/tests/resources/alert-app.yaml
+++ b/enterprise-suite/tests/resources/alert-app.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: es-alert-test
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: es-alert-test
+      annotations:
+        console-backend-e2e.io/scrape: "true"
+        console-backend-e2e.io/port: "8080"
+    spec:
+      containers:
+        # source: https://github.com/lightbend/k8s-explore/tree/master/query/nan
+        - name: es-alert-test
+          image: lightbend-docker-registry.bintray.io/enterprise-suite/es-test:v1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: metrics

--- a/enterprise-suite/tests/resources/alert-nc.yaml
+++ b/enterprise-suite/tests/resources/alert-nc.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nc-pod-service
+spec:
+  ports:
+    - port: 58585
+      targetPort: 58585
+  selector:
+    app: nc-pod
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nc-pod
+spec:
+  template:
+    metadata:
+      labels:
+        app: nc-pod
+    spec:
+      containers:
+      - name: nc-pod
+        image: appropriate/nc
+        args: [ "-lk", "-n", "58585" ]

--- a/enterprise-suite/tests/resources/alertmanager.yml
+++ b/enterprise-suite/tests/resources/alertmanager.yml
@@ -1,0 +1,13 @@
+# Used for smoke tests.  Will route alerts to a netcat listener.
+
+route:
+  group_by: ['alertname']
+  group_wait: 1s
+  group_interval: 5s
+
+  receiver: webhook
+
+receivers:
+  - name: 'webhook'
+    webhook_configs:
+      - url: 'http://nc-pod-service:58585/'

--- a/enterprise-suite/tests/smoke_alert
+++ b/enterprise-suite/tests/smoke_alert
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+#set -x
+
+## Test alerting
+
+NAMESPACE=${NAMESPACE:=lightbend}
+
+source smokecommon
+source prometheus_common
+
+# 1. Create new configmap for alertmanager deployment
+# 2. Cache existing configmap setting in deployment
+# 3. Update alertmanager deployment configs to use new configmap
+# 4. run tests
+# 5. Put original configmap back in place
+
+export alertmanager_smoke_config_dir=$(mktemp -d -t configmap.XXX)
+
+# As per https://developer.lightbend.com/docs/console/current/installation/alertmanager.html#2-create-the-configmap
+make_alertmanager_configmap() {
+  cp resources/alertmanager.yml $alertmanager_smoke_config_dir
+  cp ../alertmanager/*.tmpl $alertmanager_smoke_config_dir
+  kubectl -n $NAMESPACE create configmap alertmanager-smoke-config --from-file=$alertmanager_smoke_config_dir --dry-run -o yaml | kubectl apply -f -
+}
+
+make_alertmanager_configmap
+ORIGINAL_AM_CONFIGMAP=$( kubectl get deployment prometheus-alertmanager -n $NAMESPACE -o go-template --template="{{ (index .spec.template.spec.volumes 0).configMap.name }}" )
+kubectl patch deployment prometheus-alertmanager -n $NAMESPACE -p '{"spec":{"template":{"spec":{"volumes":[{"name":"config-volume", "configMap":{"name":"alertmanager-smoke-config"}}]}}}}'
+
+#
+# launch test apps
+#
+
+set -e
+for app in resources/alert-*.yaml ; do
+  kubectl apply -f "$app" -n $NAMESPACE --wait
+done
+
+# Wait until all deployments are up and running
+busy_wait deployments_up
+
+cleanup() {
+  for app in resources/alert-*.yaml ; do
+    kubectl delete -f "$app" -n $NAMESPACE
+  done
+  # Put alertmanager configmap back.
+  if [ -n "$ORIGINAL_AM_CONFIGMAP" ] ; then
+    kubectl patch deployment prometheus-alertmanager -n $NAMESPACE -p '{"spec":{"template":{"spec":{"volumes":[{"name":"config-volume", "configMap":{"name":"'$ORIGINAL_AM_CONFIGMAP'"}}]}}}}'
+  fi
+  if [ -n "$alertmanager_smoke_config_dir" ] ; then
+    rm -rf $alertmanager_smoke_config_dir
+  fi
+}
+
+trap cleanup 0
+set +e
+
+busy_wait prom_three_scrapes kube_pod_info
+T $? Prometheus kube-state-metrics has at least three scrapes
+
+PROM_SCRAPES=$( prom_scrapes )
+[[ PROM_SCRAPES -ge 4 ]]
+T $? "Prometheus scraping $PROM_SCRAPES targets"
+
+# app tests
+app_instances='count( count by (instance) (ohai{es_workload="es-alert-test", namespace="'$NAMESPACE'"}) ) == 1'
+busy_wait app_data "$app_instances"
+
+busy_wait prom_has_data "$app_instances"
+
+make_alerting_monitor() {
+  curl -XPOST -H "Content-Type: application/json" -H 'Author-Name: Me' -H 'Author-Email: me@lightbend.com' -H 'Message: testing!' \
+    "$ES_MONITOR_API/monitors/$1" \
+    --data @- <<EOF
+{
+  "monitorVersion": "1",
+  "model": "threshold",
+  "parameters": {
+    "metric": "$2",
+    "window": "1m",
+    "confidence": "5e-324",
+    "severity": {
+      "warning": {
+        "comparator": "!=",
+        "threshold": "3"
+      }
+    },
+    "summary": "Testing.  This should always alert.",
+    "description": "Simple monitor that should constantly alert"
+  }
+}
+EOF
+}
+
+make_alerting_monitor "es-alert-test/my_custom_monitor" "up"
+
+busy_wait model_exists my_custom_monitor
+
+alert_query='ALERTS{alertname="my_custom_monitor",alertstate="firing",severity="warning"}'
+
+prom_has_data "$alert_query"
+
+# At this point could scrape
+# http://192.168.99.101:30080/service/alertmanager/#/alerts
+# for a link like
+# http://prometheus-server-7d97556545-fqfct:9090/graph?g0.expr=health%7Bes_monitor_type%3D%22es-test%22%2Cname%3D%22my_custom_monitor%22%2Cseverity%3D%22warning%22%7D+%3E+0&g0.tab=1
+# That should use es_consle_url business if it was set.
+
+nc_pod=$( kubectl get pods -l app=nc-pod --no-headers -n $NAMESPACE | awk '{print $1}' )
+
+# If alerts are getting routed properly, we'll see them here...
+check_alert () {
+  kubectl logs -n $NAMESPACE $nc_pod | grep -q -e '"status":"firing".*"alertname":"my_custom_monitor"'
+}
+
+busy_wait check_alert
+T $? Alert getting fired by Alertmanager
+
+# Could scrape alert here to see that link to prometheus uses es_console_url
+
+test_summary

--- a/enterprise-suite/tests/smoke_prometheus
+++ b/enterprise-suite/tests/smoke_prometheus
@@ -2,23 +2,21 @@
 
 # A collection of prometheus-related smoke tests
 
+NAMESPACE=${NAMESPACE:=lightbend}
+
 source smokecommon
+source prometheus_common
 
 #
 # launch test apps
 #
 
 set -e
-NAMESPACE=${NAMESPACE:=lightbend}
 for app in resources/app*.yaml; do
   kubectl apply -f "$app" -n $NAMESPACE --wait
 done
 
-deployments_up() {
-  results=$( kubectl get pods --no-headers | awk '{print $3;}' | grep -v Running | wc -l )
-  [[ results -eq 0 ]]
-}
-
+# Wait until all deployments are up and running
 busy_wait deployments_up
 
 cleanup() {
@@ -30,83 +28,10 @@ cleanup() {
 trap cleanup 0
 set +e
 
-#
-# prometheus fetchers
-#
-
-ES_CONSOLE=$( busy_wait nodeport )
-PROM="$ES_CONSOLE/service/prometheus"
-ES_MONITOR_API="$ES_CONSOLE/service/es-monitor-api"
-
-prom_query() {
-  curl -fsG "$PROM/api/v1/query" --data-urlencode "query=$*"
-}
-
-prom_has_data() {
-  test_prom_has_data () {
-    results=$( prom_query "$@" | jq '.data.result | length' )
-    ! [[ results -eq 0 ]]
-  }
-  timeout test_prom_has_data "$@"
-  T $? timeseries: "$*"
-}
-
-prom_has_no_data() {
-  test_prom_has_data () {
-    results=$( prom_query "$@" | jq '.data.result | length' )
-    [[ results -eq 0 ]]
-  }
-  timeout test_prom_has_data "$@"
-  T $? timeseries: "$*"
-}
-
-model_exists() {
-  results=$( prom_query "model{name=\"$1\"}" | jq '.data.result | length' )
-  ! [[ results -eq 0 ]]
-}
-
-#
-# log fetchers
-#
-
-kube_state_metrics_logs() {
-  kubectl logs --tail=100 --namespace=${NAMESPACE} -l app=prometheus,component=kube-state-metrics
-}
-prom_logs() {
-  kubectl logs --tail=100 --namespace=${NAMESPACE} -l app=prometheus,component=server -c prometheus-server
-}
-
-
-# this might be useful? dunno
-# prom_interval() {
-#   prom_query "prometheus_target_interval_length_seconds" |
-#    jq -r '.data.result[0].metric.interval' |
-#    sed -e 's/[^0-9.]//g'
-# }
-# PROM_INTERVAL=$( busy_wait prom_interval )
-
-# prom_three_scrapes  waits until we've seen three scrapes of given metric
-#  two scrapes is needed to compute a rate, then three is needed for rate of rate
-
-prom_three_scrapes() {
-  results=$( prom_query "count_over_time($1[10m]) > 2" | jq '.data.result | length' )
-  ! [[ results -eq 0 ]]
-}
-
 busy_wait prom_three_scrapes kube_pod_info
 T $? Prometheus kube-state-metrics has at least three scrapes
 
-
-#
-# prometheus
-#
-
-prom_scrapes() {
-  prom_query "sum(up)" |
-   jq -r '.data.result[0].value[1]'
-}
 PROM_SCRAPES=$( prom_scrapes )
-
 [[ PROM_SCRAPES -ge 4 ]]
 T $? "Prometheus scraping $PROM_SCRAPES targets"
 
@@ -208,15 +133,9 @@ T $? 'kube-state-metrics "warn" logs'
 ! echo "$KSM_LOGS" | grep -qi err
 T $? 'kube-state-metrics "err" logs'
 
-
 # app tests
-# app via 'Pod' service discovery
 app_instances='count( count by (instance) (ohai{es_workload="es-test", namespace="'$NAMESPACE'"}) ) == 2'
-app_data() {
-  results=$( prom_query "$app_instances" | jq '.data.result | length' )
-  ! [[ results -eq 0 ]]
-}
-busy_wait app_data
+busy_wait app_data "$app_instances"
 
 prom_has_data "$app_instances"
 


### PR DESCRIPTION
The general idea here is to:

- Fire up a pod that's running a netcat server
- Create a ConfigMap for AlertManager that will route all alerts to netcat server
- Tweak AlertManager to use the new ConfigMap
- Create an alerting monitor
- Look for the alerts showing up at the netcat server
- Put things back

This borrows on the existing `smoke_prometheus` test.  The common bits have been moved to `prometheus_common`.