### PR TITLE
WIP: kubelet metrics

### DIFF
--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -92,6 +92,34 @@ scrape_configs:
 
 {{ .MonitorTypeRules | indent 6 }}
 
+  # kubelet metrics (not for monitoring, just grafana data)
+  - job_name: 'kubelet'
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecure_skip_verify: true
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    kubernetes_sd_configs:
+      - role: node
+
+    honor_labels: true
+
+    relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+      - source_labels: [__meta_kubernetes_node_name]
+        target_label: node_name
+      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+        target_label: node_ip
+
+
   # kube-state-metrics
 
   - job_name: 'kube-state-metrics'


### PR DESCRIPTION
part of lightbend/es-backend#308

This adds a little north of 100 metrics for each kubelet, cardinality ~1000. They wouldn't ever appear in our app's metric picker. Is enough load to consider filtering the collection down to the things we want, especially if you consider that a 100 node cluster may load on the order of 100,000 timeseries from this data source, when all we want are volume stats.

But I see one other issue, which is that `health` is computed for `prometheus_target_down` and `scrape_time` so I think to avoid confusion we'd want to add some filtering to those rules to avoid anything without `es_workload` labels, as these could alert but then not be shown in the UI.