### PR TITLE
Tweak output for prom_has_no_data in smoke tests

### DIFF
--- a/enterprise-suite/tests/prometheus_common
+++ b/enterprise-suite/tests/prometheus_common
@@ -41,7 +41,7 @@ prom_has_no_data() {
     [[ results -eq 0 ]]
   }
   timeout test_prom_has_data "$@"
-  T $? timeseries: "$*"
+  T $? timeseries: "expecting no data for: $*"
 }
 
 model_exists() {


### PR DESCRIPTION
This makes the output understandable.