### PR TITLE
up tests race against other tests that are bouncing apps

### DIFF
--- a/enterprise-suite/tests/smoke_prometheus
+++ b/enterprise-suite/tests/smoke_prometheus
@@ -104,9 +104,6 @@ prom_has_no_data 'kube_pod_info{es_workload=""}'
 prom_has_no_data '{__name__=~ "kube_.+", pod!="", es_workload=""}'
 # all container data have a workload label
 prom_has_no_data '{__name__=~"container_.+", es_workload=""}'
-# all targets should be reachable
-prom_has_data 'up{kubernetes_name != "es-test-service-with-only-endpoints"} == 1'
-prom_has_no_data 'up{kubernetes_name != "es-test-service-with-only-endpoints"} == 0'
 
 #
 # kube-state-metrics


### PR DESCRIPTION
remove two tests that fail from time to time, as they require everything to be up yet other tests are downing things on purpose at the same time
