### PR TITLE
readiness and metrics

### DIFF
--- a/enterprise-suite/templates/es-grafana-deployment.yaml
+++ b/enterprise-suite/templates/es-grafana-deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app: grafana
         component: server
+      annotations:
+        {{ .Values.prometheusDomain }}/scrape: "true"
+        {{ .Values.prometheusDomain }}/port: "3000"
     spec:
       {{ if .Values.podUID }}
       securityContext:
@@ -62,7 +65,7 @@ spec:
               command: ["/bin/sh", "-c", "echo \"Waiting for grafana to enable cinnamon plugin...\"; until curl --output /dev/null --silent --head --fail curl http://127.0.0.1:3000; do echo -n '.' ;  sleep 2; done ; curl -XPOST 'admin:admin@127.0.0.1:3000/api/plugins/cinnamon-prometheus-app/settings?enabled=true' -d '' || true" ]
         readinessProbe:
           httpGet:
-            path: /login
+            path: /api/health
             port: 3000
         volumeMounts:
         - name: grafana-dashboards


### PR DESCRIPTION
* use /api/health for readiness (lighter payload, made for kubernetes, doesn't stuff the log with confusing messages)

* scrape metrics

fixes lightbend/es-backend#587