### PR TITLE
Improve error reporting in failing tests

### DIFF
--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -1,5 +1,7 @@
 files := $(shell find . -path ./vendor -prune -o -name '*.go' -print)
 
+NAMESPACE := lightbend
+
 .PHONY: all
 all: check
 
@@ -24,7 +26,7 @@ vet:
 lint:
 	golint -set_exit_status $(go list ./...)
 
-.PHONY: go-tests
+.PHONY: run-tests
 run-tests:
 	ginkgo -r -- --namespace=$(NAMESPACE) --tiller-namespace=$(NAMESPACE)
 

--- a/enterprise-suite/gotests/tests/ingress/ingress_test.go
+++ b/enterprise-suite/gotests/tests/ingress/ingress_test.go
@@ -2,12 +2,13 @@ package ingress
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"testing"
 
 	extv1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/lightbend/gotests/args"
 	"github.com/lightbend/gotests/testenv"
@@ -89,10 +90,18 @@ var _ = Describe("minikube:ingress", func() {
 
 		req.Host = "minikube.ingress.test"
 
-		err = util.WaitUntilTrue(func() bool {
+		err = util.WaitUntilTrue(func() error {
 			resp, err := httpClient.Do(req)
-			return err == nil && resp.StatusCode == 200
-		}, "console not accessible through minikube ingress")
+			if err != nil {
+				return fmt.Errorf("console not accessible through ingress: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 200 {
+				body, _ := ioutil.ReadAll(resp.Body)
+				return fmt.Errorf("wanted 200 response, got %d: %s", resp.StatusCode, string(body))
+			}
+			return nil
+		})
 		Expect(err).To(Succeed())
 	})
 })

--- a/enterprise-suite/gotests/tests/ingress/ingress_test.go
+++ b/enterprise-suite/gotests/tests/ingress/ingress_test.go
@@ -90,7 +90,7 @@ var _ = Describe("minikube:ingress", func() {
 
 		req.Host = "minikube.ingress.test"
 
-		err = util.WaitUntilTrue(func() error {
+		err = util.WaitUntilSuccess(func() error {
 			resp, err := httpClient.Do(req)
 			if err != nil {
 				return fmt.Errorf("console not accessible through ingress: %v", err)

--- a/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
+++ b/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
@@ -39,9 +39,9 @@ var _ = BeforeSuite(func() {
 
 		// Wait for deployment to become ready
 		if len(depName) > 0 {
-			err = util.WaitUntilTrue(func() bool {
+			err = util.WaitUntilTrue(func() error {
 				return kube.IsDeploymentAvailable(testenv.K8sClient, args.ConsoleNamespace, depName)
-			}, fmt.Sprintf("deployment %v did not become available", depName))
+			})
 			Expect(err).To(Succeed())
 		}
 	}
@@ -53,21 +53,23 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(Succeed())
 
 	// Returns true if there were at least three scrapes of a given metric
-	threeScrapes := func(metric string) bool {
+	threeScrapes := func(metric string) error {
 		return prom.HasData(fmt.Sprintf("count_over_time(%v[10m]) > 2", metric))
 	}
 
 	// Wait until there's some scrapes finished
-	err = util.WaitUntilTrue(func() bool {
+	err = util.WaitUntilTrue(func() error {
 		return threeScrapes("kube_pod_info")
-	}, "no kube_pod_info metric scrapes found")
+	})
 	Expect(err).To(Succeed())
 })
 
 var _ = AfterSuite(func() {
 	// Delete test app deployments + services
 	for res := range appYamls {
-		kube.DeleteYaml(args.ConsoleNamespace, res)
+		if err := kube.DeleteYaml(args.ConsoleNamespace, res); err != nil {
+			panic(err)
+		}
 
 		// Ignore failures for now because deleting
 		// 'es-test-service-with-only-endpoints' fails for some reason
@@ -85,7 +87,7 @@ var _ = Describe("all:prometheus", func() {
 
 	DescribeTable("basic metrics available",
 		func(metric string) {
-			Expect(prom.HasData(metric)).To(BeTrue())
+			Expect(prom.HasData(metric)).To(Succeed())
 		},
 		Metric("prometheus_notifications_dropped_rate"),
 		Metric("prometheus_notification_queue_percent"),
@@ -98,8 +100,8 @@ var _ = Describe("all:prometheus", func() {
 
 	DescribeTable("health metrics available",
 		func(metric string) {
-			Expect(prom.HasData(fmt.Sprintf("model{name=\"%v\"}", metric))).To(BeTrue())
-			Expect(prom.HasData(fmt.Sprintf("health{name=\"%v\"}", metric))).To(BeTrue())
+			Expect(prom.HasData(fmt.Sprintf("model{name=\"%v\"}", metric))).To(Succeed())
+			Expect(prom.HasData(fmt.Sprintf("health{name=\"%v\"}", metric))).To(Succeed())
 		},
 		Metric("prometheus_notifications_dropped"),
 		Metric("prometheus_notification_queue"),
@@ -113,26 +115,26 @@ var _ = Describe("all:prometheus", func() {
 
 	It("coherency", func() {
 		// Data with "es_workload" should also have a "namespace" label
-		Expect(prom.HasData("count({es_workload=~\".+\", namespace=\"\", name!~\"node.*|kube_node.*\", __name__!~\"node.*|kube_node.*\"})")).To(BeFalse())
+		Expect(prom.HasData("count({es_workload=~\".+\", namespace=\"\", name!~\"node.*|kube_node.*\", __name__!~\"node.*|kube_node.*\"})")).ToNot(Succeed())
 		// Health should have "es_workload" label, with a few known exceptions
-		Expect(prom.HasData("health{es_workload=\"\", name!~\"node.*|kube_node.*|prometheus_target_down|scrape_time\"}")).To(BeFalse())
+		Expect(prom.HasData("health{es_workload=\"\", name!~\"node.*|kube_node.*|prometheus_target_down|scrape_time\"}")).ToNot(Succeed())
 
 		// kube_pod_info must have es_workload labels (flaky!)
 		//Expect(prom.HasData("kube_pd_info{es_workload=~\".+\"}")).To(BeTrue())
 
-		Expect(prom.HasData("kube_pod_info{es_workload=\"\"}")).To(BeFalse())
+		Expect(prom.HasData("kube_pod_info{es_workload=\"\"}")).ToNot(Succeed())
 		// kube data mapped pod to workload labels
-		Expect(prom.HasData("{__name__=~ \"kube_.+\", pod!=\"\", es_workload=\"\"}")).To(BeFalse())
+		Expect(prom.HasData("{__name__=~ \"kube_.+\", pod!=\"\", es_workload=\"\"}")).ToNot(Succeed())
 		// All container data have a workload label
-		Expect(prom.HasData("{__name__=~\"container_.+\", es_workload=\"\"}")).To(BeFalse())
+		Expect(prom.HasData("{__name__=~\"container_.+\", es_workload=\"\"}")).ToNot(Succeed())
 		// All targets should be reachable
-		Expect(prom.HasData("up{kubernetes_name != \"es-test-service-with-only-endpoints\"} == 1")).To(BeTrue())
-		Expect(prom.HasData("up{kubernetes_name != \"es-test-service-with-only-endpoints\"} == 0")).To(BeFalse())
+		Expect(prom.HasData("up{kubernetes_name != \"es-test-service-with-only-endpoints\"} == 1")).To(Succeed())
+		Expect(prom.HasData("up{kubernetes_name != \"es-test-service-with-only-endpoints\"} == 0")).ToNot(Succeed())
 	})
 
 	DescribeTable("kube state metrics",
 		func(metric string) {
-			Expect(prom.HasData(metric)).To(BeTrue())
+			Expect(prom.HasData(metric)).To(Succeed())
 		},
 		Metric("kube_pod_info"),
 		Metric("kube_pod_ready"),
@@ -144,8 +146,8 @@ var _ = Describe("all:prometheus", func() {
 
 	DescribeTable("kube state health",
 		func(metric string) {
-			Expect(prom.HasData(fmt.Sprintf("model{name=\"%v\"}", metric))).To(BeTrue())
-			Expect(prom.HasData(fmt.Sprintf("health{name=\"%v\"}", metric))).To(BeTrue())
+			Expect(prom.HasData(fmt.Sprintf("model{name=\"%v\"}", metric))).To(Succeed())
+			Expect(prom.HasData(fmt.Sprintf("health{name=\"%v\"}", metric))).To(Succeed())
 		},
 		Metric("kube_container_restarts"),
 		Metric("kube_pod_not_ready"),
@@ -155,76 +157,93 @@ var _ = Describe("all:prometheus", func() {
 
 	// TODO: Check kube-state-metrics logs
 
-	Context("app discovery", func() {
-		It("'Pod' service", func() {
+	Context("k8s service discovery", func() {
+		It("can discover a pod", func() {
 			appInstancesQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test\", namespace=\"%v\"}) ) == 2", args.ConsoleNamespace)
-			err := util.WaitUntilTrue(func() bool {
+			err := util.WaitUntilTrue(func() error {
 				return prom.HasData(appInstancesQuery)
-			}, "unable to discover app via pod service discovery")
+			})
 			Expect(err).To(Succeed())
+		})
 
-			// Pod discovery - automatic metrics should gain an es_monitor_type label when a custom monitor is created
+		It("can create monitors on automatic metrics for Pods, aka `up`", func() {
 			Expect(esMonitor.MakeMonitor("es-test/my_custom_monitor", "up")).To(Succeed())
-			err = util.WaitUntilTrue(func() bool {
+			err := util.WaitUntilTrue(func() error {
 				return prom.HasModel("my_custom_monitor")
-			}, "monitor my_custom_monitor wasn't created correctly")
+			})
+			Expect(err).To(Succeed())
+
+			err = util.WaitUntilTrue(func() error {
+				return prom.HasData(`up{es_workload="es-test", es_monitor_type="es-test"}`)
+			})
 			Expect(err).To(Succeed())
 		})
 
-		It("'Pod' service with multiple ports", func() {
+		It("can discover a pod with multiple ports", func() {
 			appInstancesWithMultiplePortsQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test-with-multiple-ports\", namespace=\"%v\"}) ) == 4", args.ConsoleNamespace)
-			err := util.WaitUntilTrue(func() bool {
+			err := util.WaitUntilTrue(func() error {
 				return prom.HasData(appInstancesWithMultiplePortsQuery)
-			}, "unable to discover app with multiple ports")
+			})
 			Expect(err).To(Succeed())
 		})
 
-		It("'Service' discovery", func() {
+		It("can discover k8s `Service` resources", func() {
 			appInstancesViaServiceQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test-via-service\", namespace=\"%v\"}) ) == 2", args.ConsoleNamespace)
-			err := util.WaitUntilTrue(func() bool {
-				return prom.HasData(appInstancesViaServiceQuery)
-			}, "unable to discover app via 'Service' service discovery")
+			err := util.WaitUntilTrue(func() error {
+				if err := prom.HasData(appInstancesViaServiceQuery); err != nil {
+					return fmt.Errorf("unable to discover app via 'Service' service discovery: %v", err)
+				}
+				return nil
+			})
 			Expect(err).To(Succeed())
+		})
 
+		It("can create monitors on automatic metrics for Services, aka `up`", func() {
 			// 'Service' discovery - automatic metrics should gain an es_monitor_type label when a custom monitor is created
 			Expect(esMonitor.MakeMonitor("es-test-via-service/my_custom_monitor_for_service", "up")).To(Succeed())
-			err = util.WaitUntilTrue(func() bool {
+			err := util.WaitUntilTrue(func() error {
 				return prom.HasModel("my_custom_monitor_for_service")
-			}, "monitor my_custom_monitor_for_service wasn't created correctly")
+			})
 			Expect(err).To(Succeed())
-			Expect(prom.HasData("up{es_workload=\"es-test-via-service\", es_monitor_type=\"es-test-via-service\"}")).To(BeTrue())
+
+			err = util.WaitUntilTrue(func() error {
+				return prom.HasData("up{es_workload=\"es-test-via-service\", es_monitor_type=\"es-test-via-service\"}")
+			})
+			Expect(err).To(Succeed())
 		})
 
-		It("'Service' endpoint discovery", func() {
-			err := util.WaitUntilTrue(func() bool {
+		It("can discover Services without any pods, only endpoints, to support external redirection", func() {
+			err := util.WaitUntilTrue(func() error {
 				return prom.HasData(fmt.Sprintf("count( count by (instance) (up{ "+
 					"job=\"kubernetes-services\", kubernetes_name=\"es-test-service-with-only-endpoints\", namespace=\"%v\""+
 					"}) ) == 1", args.ConsoleNamespace))
-			}, "unable to discover app with only endpoints")
+			})
 			Expect(err).To(Succeed())
 		})
 
-		It("kubernetes-cadvisor metrics", func() {
+		It("kubelet cadvisor metrics should have a es_monitor_type label", func() {
 			// kubernetes-cadvisor metrics should have an es_monitor_type label.
 			Expect(esMonitor.MakeMonitor("es-test/es-monitor-type-test", "container_cpu_load_average_10s")).To(Succeed())
-			err := util.WaitUntilTrue(func() bool {
+			err := util.WaitUntilTrue(func() error {
 				return prom.HasModel("es-monitor-type-test")
-			}, "monitor es-monitor-type-test wasn't created correctly")
+			})
+			Expect(err).To(Succeed())
+
+			err = util.WaitUntilTrue(func() error {
+				return prom.HasData(`{job="kubernetes-cadvisor", es_monitor_type="es-test"}`)
+			})
 			Expect(err).To(Succeed())
 		})
 
-		It("kubernetes-cadvisor regression", func() {
-			// Specific test for regression of es-backend/issues/430.
-			Expect(prom.HasData("{job=\"kubernetes-cadvisor\",es_monitor_type=\"es-test\"}")).To(BeTrue())
-		})
-
-		// The following is disabled due to flakyness
 		XIt("metric data has es_monitor_type", func() {
 			// Succeeds if all data for the workload es-test  has a matching es_monitor_type
 			// Note we're currently ignoring health metrics because 'bad' data can stick around for 15m given their time window.
-			err := util.WaitUntilTrue(func() bool {
-				return prom.HasData("{es_workload=\"es-test\", es_monitor_type!=\"es-test\", __name__!=\"health\"}")
-			}, "some data of es-test workload doesn't have matching es_monitor_type")
+			err := util.WaitUntilTrue(func() error {
+				if err := prom.HasData(`{es_workload="es-test", es_monitor_type!="es-test", __name__!="health"}`); err != nil {
+					return fmt.Errorf("es-test workload data is missing es_monitor_type label: %v", err)
+				}
+				return nil
+			})
 			Expect(err).To(Succeed())
 		})
 	})

--- a/enterprise-suite/gotests/util/util.go
+++ b/enterprise-suite/gotests/util/util.go
@@ -193,8 +193,8 @@ const maxRepeats = 30
 const firstSleepMs = 20
 const maxSleepMs = 10000
 
-// Repeatedly runs a function, sleeping for a bit after each time, until it returns true or reaches maxRepeats.
-func WaitUntilTrue(f func() error) error {
+// Repeatedly runs a function, sleeping for a bit after each time, until it returns nil or reaches maxRepeats.
+func WaitUntilSuccess(f func() error) error {
 	sleepTimeMs := firstSleepMs
 	var lastErr error
 	for i := 0; i < maxRepeats; i++ {
@@ -209,5 +209,5 @@ func WaitUntilTrue(f func() error) error {
 		time.Sleep(time.Duration(sleepTimeMs) * time.Millisecond)
 	}
 
-	return fmt.Errorf("WaitUntilTrue reached maximum repeats without f() succeeding: %v", lastErr)
+	return fmt.Errorf("WaitUntilSuccess reached maximum repeats without f() succeeding: %v", lastErr)
 }


### PR DESCRIPTION
Also:

* Fix missing test coverage in some places that wasn't ported over.
* Return errors everywhere rather than bool, to ensure tests are
reporting errors.