### PR TITLE
Re-enable openshift go tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,10 @@ jobs:
     - travis_retry scripts/setup-minikube-for-linux.sh
     - GO111MODULE=on make -C enterprise-suite install-helm gotests-minikube
 
-  # something changed in Centralpark cluster and broke this test on 2/7/2019
-  # - name: Backend E2E Go Tests - Openshift
-  #   script:
-  #   - travis_retry scripts/setup-openshift.sh ${OC_GOTESTS_TOKEN}
-  #   - GO111MODULE=on make -C enterprise-suite gotests-openshift NAMESPACE=console-backend-go-tests
+  - name: Backend E2E Go Tests - Openshift
+    script:
+    - travis_retry scripts/setup-openshift.sh ${OC_GOTESTS_TOKEN}
+    - GO111MODULE=on make -C enterprise-suite gotests-openshift NAMESPACE=console-backend-go-tests
 
   - name: Backend E2E Tests - Minikube Latest
     # Only build latest in the daily cron - don't block PRs or master releases.


### PR DESCRIPTION
These were disabled due to invalidated oc login token. Now uses robot service account, should be alright.