### PR TITLE
Add checksum annotations to guarantee pod restart when configmap changes

### DIFF
--- a/enterprise-suite/templates/alertmanager-deployment.yaml
+++ b/enterprise-suite/templates/alertmanager-deployment.yaml
@@ -21,6 +21,8 @@ spec:
       component: alertmanager
   template:
     metadata:
+      annotations:
+        checksum/alertmanager-config: {{ (.Files.Glob "alertmanager/*").AsConfig | sha256sum }}
       labels:
         app: prometheus
         component: alertmanager

--- a/enterprise-suite/templates/es-console-deployment.yaml
+++ b/enterprise-suite/templates/es-console-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        checksum/es-console-config: {{ include (print $.Template.BasePath "/es-console-configmap.yaml") . | sha256sum }}
       labels:
         run: es-console
     spec:

--- a/enterprise-suite/templates/es-grafana-deployment.yaml
+++ b/enterprise-suite/templates/es-grafana-deployment.yaml
@@ -22,6 +22,8 @@ spec:
       annotations:
         {{ .Values.prometheusDomain }}/scrape: "true"
         {{ .Values.prometheusDomain }}/port: "3000"
+        checksum/datasource-config: {{ include (print $.Template.BasePath "/es-grafana-configmap-datasource.yaml") . | sha256sum }}
+        checksum/plugin-config: {{ (.Files.Glob "es-grafana/*").AsConfig | sha256sum }}
     spec:
       {{ if .Values.podUID }}
       securityContext:

--- a/enterprise-suite/templates/prometheus-deployment.yaml
+++ b/enterprise-suite/templates/prometheus-deployment.yaml
@@ -19,7 +19,6 @@ spec:
       app: prometheus
       component: server
   template:
-
     metadata:
       labels:
         app: prometheus

--- a/enterprise-suite/templates/prometheus-deployment.yaml
+++ b/enterprise-suite/templates/prometheus-deployment.yaml
@@ -19,12 +19,15 @@ spec:
       app: prometheus
       component: server
   template:
+
     metadata:
       labels:
         app: prometheus
         component: server
       annotations:
         {{ .Values.prometheusDomain }}/scrape: "true"
+        checksum/es-monitor-api-config: {{ (.Files.Glob "es-monitor-api/*").AsConfig | sha256sum }}
+        checksum/bare-prometheus-config: {{ include (print $.Template.BasePath "/prometheus-configmap-prom.yaml") . | sha256sum }}
     spec:
       serviceAccountName: prometheus-server
 


### PR DESCRIPTION
lightbend/es-backend/issues/564
Verified pods restarts by changing the following 
es-grafana-configmap-datasource.yaml
es-grafana-configmap-datasource.yaml
es-grafana/akka-exporter.json
alertmanager/alertmanager.yaml 
es-monitor-api/default-monitors.json