### PR TITLE
Port forwarding test in go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ jobs:
     - make -C enterprise-suite openshift-backend-tests
 
   - name: Backend E2E Go Tests - Minikube
+    cache:
+      directories:
+        - $HOME/.cache/go-build
+        - $HOME/gopath/pkg/mod
     script:
     - travis_retry scripts/setup-minikube-for-linux.sh
     - GO111MODULE=on make -C enterprise-suite install-helm gotests-minikube
@@ -39,6 +43,10 @@ jobs:
     - sleep 5
 
   - name: Backend E2E Go Tests - Openshift
+    cache:
+      directories:
+        - $HOME/.cache/go-build
+        - $HOME/gopath/pkg/mod
     script:
     - travis_retry scripts/setup-openshift.sh ${OC_GOTESTS_TOKEN}
     - GO111MODULE=on CLEANUP=true make -C enterprise-suite gotests-openshift NAMESPACE=console-backend-go-tests

--- a/enterprise-suite/gotests/tests/portforward/portforward_test.go
+++ b/enterprise-suite/gotests/tests/portforward/portforward_test.go
@@ -18,14 +18,17 @@ import (
 const consoleRemotePort = 8080
 const consoleDeployment = "deployment/es-console"
 
-// Hardcode the local port because with random port setup it's currently
-// tricky to get cmd.StartAsync stdout without stopping it first.
-const localPort = 58363
-
-var portForwardCmd *util.CmdBuilder
+var (
+	portForwardCmd *util.CmdBuilder
+	localPort      int
+)
 
 var _ = BeforeSuite(func() {
 	testenv.InitEnv()
+
+	var err error
+	localPort, err = util.FindFreePort()
+	Expect(err).To(Succeed())
 
 	portForwardCmd = util.Cmd("kubectl", "port-forward",
 		"-n", args.ConsoleNamespace,

--- a/enterprise-suite/gotests/tests/portforward/portforward_test.go
+++ b/enterprise-suite/gotests/tests/portforward/portforward_test.go
@@ -1,0 +1,71 @@
+package ingress
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/lightbend/gotests/args"
+	"github.com/lightbend/gotests/testenv"
+
+	"github.com/lightbend/gotests/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const consoleRemotePort = 8080
+const consoleDeployment = "deployment/es-console"
+
+// Hardcode the local port because with random port setup it's currently
+// tricky to get cmd.StartAsync stdout without stopping it first.
+const localPort = 58363
+
+var portForwardCmd *util.CmdBuilder
+
+var _ = BeforeSuite(func() {
+	testenv.InitEnv()
+
+	portForwardCmd = util.Cmd("kubectl", "port-forward",
+		"-n", args.ConsoleNamespace,
+		consoleDeployment,
+		fmt.Sprintf("%d:%d", localPort, consoleRemotePort))
+	Expect(portForwardCmd.StartAsync()).To(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	Expect(portForwardCmd.StopAsync()).To(Succeed())
+	testenv.CloseEnv()
+})
+
+var _ = Describe("all:portforward", func() {
+	It("forwards 127.0.0.1 requests to console", func() {
+		addr := fmt.Sprintf("http://127.0.0.1:%v", localPort)
+
+		err := util.WaitUntilSuccess(func() error {
+			resp, err := http.Get(addr)
+			if err != nil {
+				return err
+			}
+
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+
+			if resp.StatusCode != 200 {
+				return fmt.Errorf("wanted 200 response, got %d: %s", resp.StatusCode, string(body))
+			}
+
+			return nil
+		})
+		Expect(err).To(Succeed())
+	})
+})
+
+func TestPortForward(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Port Forward Suite")
+}

--- a/enterprise-suite/gotests/util/util.go
+++ b/enterprise-suite/gotests/util/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -243,4 +244,14 @@ func Close(closer io.Closer) {
 		// we never expect close to fail
 		panic(err)
 	}
+}
+
+// Returns a free TCP port on the local machine or an error
+func FindFreePort() (int, error) {
+	conn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+	return conn.Addr().(*net.TCPAddr).Port, nil
 }


### PR DESCRIPTION
For https://github.com/lightbend/console-backend/issues/556

This PR also turns on Travis caching of go modules and build cache, it saves ~1-2 minutes of build time.