### PR TITLE
Add apiserver proxy tests

### DIFF
--- a/enterprise-suite/gotests/testenv/testenv.go
+++ b/enterprise-suite/gotests/testenv/testenv.go
@@ -97,7 +97,7 @@ func InitEnv() {
 		for {
 			select {
 			case <-ticker.C:
-				if _, err := fmt.Fprintf(os.Stderr, "lbc.py installation is still ongoing [%fs]...", time.Now().Sub(start).Seconds()); err != nil {
+				if _, err := fmt.Fprintf(os.Stderr, "\nlbc.py installation is still ongoing [%fs]...\n", time.Now().Sub(start).Seconds()); err != nil {
 					panic(err)
 				}
 			case <-done:

--- a/enterprise-suite/gotests/testenv/testenv.go
+++ b/enterprise-suite/gotests/testenv/testenv.go
@@ -97,10 +97,13 @@ func InitEnv() {
 		for {
 			select {
 			case <-ticker.C:
-				if _, err := fmt.Fprintf(os.Stderr, "\nlbc.py installation is still ongoing [%fs]...\n", time.Now().Sub(start).Seconds()); err != nil {
+				if _, err := fmt.Fprintf(os.Stderr, "\nlbc.py installation is still ongoing [%fs]...", time.Now().Sub(start).Seconds()); err != nil {
 					panic(err)
 				}
 			case <-done:
+				if _, err := fmt.Fprintf(os.Stderr, "\n"); err != nil {
+					panic(err)
+				}
 				return
 			}
 		}

--- a/enterprise-suite/gotests/testenv/testenv.go
+++ b/enterprise-suite/gotests/testenv/testenv.go
@@ -97,11 +97,11 @@ func InitEnv() {
 		for {
 			select {
 			case <-ticker.C:
-				if _, err := fmt.Fprintf(os.Stderr, "\nlbc.py installation is still ongoing [%fs]...", time.Now().Sub(start).Seconds()); err != nil {
+				if _, err := fmt.Fprintf(os.Stdout, "\nlbc.py installation is still ongoing [%.0fs]...", time.Now().Sub(start).Seconds()); err != nil {
 					panic(err)
 				}
 			case <-done:
-				if _, err := fmt.Fprintf(os.Stderr, "\n"); err != nil {
+				if _, err := fmt.Fprintf(os.Stdout, "\n"); err != nil {
 					panic(err)
 				}
 				return

--- a/enterprise-suite/gotests/testenv/testenv.go
+++ b/enterprise-suite/gotests/testenv/testenv.go
@@ -91,12 +91,15 @@ func InitEnv() {
 
 	// Create an async goroutine to report when install is taking a while.
 	ticker := time.NewTicker(15 * time.Second)
+	start := time.Now()
 	done := make(chan struct{})
 	go func() {
 		for {
 			select {
 			case <-ticker.C:
-				fmt.Fprintf(os.Stderr, "lbc.py installation is still ongoing, please check your environment if it's taking too long...")
+				if _, err := fmt.Fprintf(os.Stderr, "lbc.py installation is still ongoing [%fs]...", time.Now().Sub(start).Seconds()); err != nil {
+					panic(err)
+				}
 			case <-done:
 				return
 			}

--- a/enterprise-suite/gotests/tests/apiserverproxy/apiserverproxy_test.go
+++ b/enterprise-suite/gotests/tests/apiserverproxy/apiserverproxy_test.go
@@ -40,7 +40,7 @@ var _ = Describe("all:apiserverproxy", func() {
 			proxyPort, args.ConsoleNamespace, serviceName, servicePath)
 		By(url)
 
-		err := util.WaitUntilSuccess(func() error {
+		err := util.WaitUntilSuccess(util.SmallWait, func() error {
 			resp, err := http.Get(url)
 			if err != nil {
 				return err
@@ -55,7 +55,7 @@ var _ = Describe("all:apiserverproxy", func() {
 			}
 
 			return nil
-		}, util.SmallWait)
+		})
 
 		Expect(err).ToNot(HaveOccurred())
 	},

--- a/enterprise-suite/gotests/tests/ingress/ingress_test.go
+++ b/enterprise-suite/gotests/tests/ingress/ingress_test.go
@@ -90,7 +90,7 @@ var _ = Describe("minikube:ingress", func() {
 
 		req.Host = "minikube.ingress.test"
 
-		err = util.WaitUntilSuccess(func() error {
+		err = util.WaitUntilSuccess(util.LongWait, func() error {
 			resp, err := httpClient.Do(req)
 			if err != nil {
 				return fmt.Errorf("console not accessible through ingress: %v", err)
@@ -101,7 +101,7 @@ var _ = Describe("minikube:ingress", func() {
 				return fmt.Errorf("wanted 200 response, got %d: %s", resp.StatusCode, string(body))
 			}
 			return nil
-		}, util.LongWait)
+		})
 		Expect(err).To(Succeed())
 	})
 })

--- a/enterprise-suite/gotests/tests/ingress/ingress_test.go
+++ b/enterprise-suite/gotests/tests/ingress/ingress_test.go
@@ -101,7 +101,7 @@ var _ = Describe("minikube:ingress", func() {
 				return fmt.Errorf("wanted 200 response, got %d: %s", resp.StatusCode, string(body))
 			}
 			return nil
-		})
+		}, util.LongWait)
 		Expect(err).To(Succeed())
 	})
 })

--- a/enterprise-suite/gotests/tests/portforward/portforward_test.go
+++ b/enterprise-suite/gotests/tests/portforward/portforward_test.go
@@ -43,7 +43,7 @@ var _ = Describe("all:portforward", func() {
 	It("forwards 127.0.0.1 requests to console", func() {
 		addr := fmt.Sprintf("http://127.0.0.1:%v", localPort)
 
-		err := util.WaitUntilSuccess(func() error {
+		err := util.WaitUntilSuccess(util.SmallWait, func() error {
 			resp, err := http.Get(addr)
 			if err != nil {
 				return err
@@ -60,7 +60,7 @@ var _ = Describe("all:portforward", func() {
 			}
 
 			return nil
-		}, util.SmallWait)
+		})
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/enterprise-suite/gotests/tests/portforward/portforward_test.go
+++ b/enterprise-suite/gotests/tests/portforward/portforward_test.go
@@ -26,10 +26,7 @@ var (
 var _ = BeforeSuite(func() {
 	testenv.InitEnv()
 
-	var err error
-	localPort, err = util.FindFreePort()
-	Expect(err).To(Succeed())
-
+	localPort = util.FindFreePort()
 	portForwardCmd = util.Cmd("kubectl", "port-forward",
 		"-n", args.ConsoleNamespace,
 		consoleDeployment,
@@ -63,8 +60,8 @@ var _ = Describe("all:portforward", func() {
 			}
 
 			return nil
-		})
-		Expect(err).To(Succeed())
+		}, util.SmallWait)
+		Expect(err).ToNot(HaveOccurred())
 	})
 })
 

--- a/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
+++ b/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
@@ -41,7 +41,7 @@ var _ = BeforeSuite(func() {
 		if len(depName) > 0 {
 			err = util.WaitUntilSuccess(func() error {
 				return kube.IsDeploymentAvailable(testenv.K8sClient, args.ConsoleNamespace, depName)
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 		}
 	}
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func() {
 	// wait until there's some scrapes finished
 	err = util.WaitUntilSuccess(func() error {
 		return threeScrapes("kube_pod_info")
-	})
+	}, util.LongWait)
 	Expect(err).To(Succeed())
 })
 
@@ -158,7 +158,7 @@ var _ = Describe("all:prometheus", func() {
 			appInstancesQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test\", namespace=\"%v\"}) ) == 2", args.ConsoleNamespace)
 			err := util.WaitUntilSuccess(func() error {
 				return prom.HasData(appInstancesQuery)
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 		})
 
@@ -166,12 +166,12 @@ var _ = Describe("all:prometheus", func() {
 			Expect(esMonitor.MakeMonitor("es-test/my_custom_monitor", "up")).To(Succeed())
 			err := util.WaitUntilSuccess(func() error {
 				return prom.HasModel("my_custom_monitor")
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 
 			err = util.WaitUntilSuccess(func() error {
 				return prom.HasData(`up{es_workload="es-test", es_monitor_type="es-test"}`)
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 		})
 
@@ -179,7 +179,7 @@ var _ = Describe("all:prometheus", func() {
 			appInstancesWithMultiplePortsQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test-with-multiple-ports\", namespace=\"%v\"}) ) == 4", args.ConsoleNamespace)
 			err := util.WaitUntilSuccess(func() error {
 				return prom.HasData(appInstancesWithMultiplePortsQuery)
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 		})
 
@@ -190,7 +190,7 @@ var _ = Describe("all:prometheus", func() {
 					return fmt.Errorf("unable to discover app via 'Service' service discovery: %v", err)
 				}
 				return nil
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 		})
 
@@ -199,12 +199,12 @@ var _ = Describe("all:prometheus", func() {
 			Expect(esMonitor.MakeMonitor("es-test-via-service/my_custom_monitor_for_service", "up")).To(Succeed())
 			err := util.WaitUntilSuccess(func() error {
 				return prom.HasModel("my_custom_monitor_for_service")
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 
 			err = util.WaitUntilSuccess(func() error {
 				return prom.HasData("up{es_workload=\"es-test-via-service\", es_monitor_type=\"es-test-via-service\"}")
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 		})
 
@@ -213,7 +213,7 @@ var _ = Describe("all:prometheus", func() {
 				return prom.HasData(fmt.Sprintf("count( count by (instance) (up{ "+
 					"job=\"kubernetes-services\", kubernetes_name=\"es-test-service-with-only-endpoints\", namespace=\"%v\""+
 					"}) ) == 1", args.ConsoleNamespace))
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 		})
 
@@ -222,12 +222,12 @@ var _ = Describe("all:prometheus", func() {
 			Expect(esMonitor.MakeMonitor("es-test/es-monitor-type-test", "container_cpu_load_average_10s")).To(Succeed())
 			err := util.WaitUntilSuccess(func() error {
 				return prom.HasModel("es-monitor-type-test")
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 
 			err = util.WaitUntilSuccess(func() error {
 				return prom.HasData(`{job="kubernetes-cadvisor", es_monitor_type="es-test"}`)
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 		})
 
@@ -239,7 +239,7 @@ var _ = Describe("all:prometheus", func() {
 					return fmt.Errorf("es-test workload data is missing es_monitor_type label: %v", err)
 				}
 				return nil
-			})
+			}, util.LongWait)
 			Expect(err).To(Succeed())
 		})
 	})

--- a/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
+++ b/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
@@ -39,9 +39,9 @@ var _ = BeforeSuite(func() {
 
 		// wait for deployment to become ready
 		if len(depName) > 0 {
-			err = util.WaitUntilSuccess(func() error {
+			err = util.WaitUntilSuccess(util.LongWait, func() error {
 				return kube.IsDeploymentAvailable(testenv.K8sClient, args.ConsoleNamespace, depName)
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 		}
 	}
@@ -58,9 +58,9 @@ var _ = BeforeSuite(func() {
 	}
 
 	// wait until there's some scrapes finished
-	err = util.WaitUntilSuccess(func() error {
+	err = util.WaitUntilSuccess(util.LongWait, func() error {
 		return threeScrapes("kube_pod_info")
-	}, util.LongWait)
+	})
 	Expect(err).To(Succeed())
 })
 
@@ -156,90 +156,90 @@ var _ = Describe("all:prometheus", func() {
 	Context("k8s service discovery", func() {
 		It("can discover a pod", func() {
 			appInstancesQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test\", namespace=\"%v\"}) ) == 2", args.ConsoleNamespace)
-			err := util.WaitUntilSuccess(func() error {
+			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasData(appInstancesQuery)
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 		})
 
 		It("can create monitors on automatic metrics for Pods, aka `up`", func() {
 			Expect(esMonitor.MakeMonitor("es-test/my_custom_monitor", "up")).To(Succeed())
-			err := util.WaitUntilSuccess(func() error {
+			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasModel("my_custom_monitor")
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 
-			err = util.WaitUntilSuccess(func() error {
+			err = util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasData(`up{es_workload="es-test", es_monitor_type="es-test"}`)
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 		})
 
 		It("can discover a pod with multiple ports", func() {
 			appInstancesWithMultiplePortsQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test-with-multiple-ports\", namespace=\"%v\"}) ) == 4", args.ConsoleNamespace)
-			err := util.WaitUntilSuccess(func() error {
+			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasData(appInstancesWithMultiplePortsQuery)
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 		})
 
 		It("can discover k8s `Service` resources", func() {
 			appInstancesViaServiceQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test-via-service\", namespace=\"%v\"}) ) == 2", args.ConsoleNamespace)
-			err := util.WaitUntilSuccess(func() error {
+			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				if err := prom.HasData(appInstancesViaServiceQuery); err != nil {
 					return fmt.Errorf("unable to discover app via 'Service' service discovery: %v", err)
 				}
 				return nil
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 		})
 
 		It("can create monitors on automatic metrics for Services, aka `up`", func() {
 			// 'Service' discovery - automatic metrics should gain an es_monitor_type label when a custom monitor is created
 			Expect(esMonitor.MakeMonitor("es-test-via-service/my_custom_monitor_for_service", "up")).To(Succeed())
-			err := util.WaitUntilSuccess(func() error {
+			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasModel("my_custom_monitor_for_service")
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 
-			err = util.WaitUntilSuccess(func() error {
+			err = util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasData("up{es_workload=\"es-test-via-service\", es_monitor_type=\"es-test-via-service\"}")
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 		})
 
 		It("can discover Services without any pods, only endpoints, to support external redirection", func() {
-			err := util.WaitUntilSuccess(func() error {
+			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasData(fmt.Sprintf("count( count by (instance) (up{ "+
 					"job=\"kubernetes-services\", kubernetes_name=\"es-test-service-with-only-endpoints\", namespace=\"%v\""+
 					"}) ) == 1", args.ConsoleNamespace))
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 		})
 
 		It("kubelet cadvisor metrics should have a es_monitor_type label", func() {
 			// kubernetes-cadvisor metrics should have an es_monitor_type label.
 			Expect(esMonitor.MakeMonitor("es-test/es-monitor-type-test", "container_cpu_load_average_10s")).To(Succeed())
-			err := util.WaitUntilSuccess(func() error {
+			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasModel("es-monitor-type-test")
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 
-			err = util.WaitUntilSuccess(func() error {
+			err = util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasData(`{job="kubernetes-cadvisor", es_monitor_type="es-test"}`)
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 		})
 
 		XIt("metric data has es_monitor_type", func() {
 			// Succeeds if all data for the workload es-test  has a matching es_monitor_type
 			// Note we're currently ignoring health metrics because 'bad' data can stick around for 15m given their time window.
-			err := util.WaitUntilSuccess(func() error {
+			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				if err := prom.HasData(`{es_workload="es-test", es_monitor_type!="es-test", __name__!="health"}`); err != nil {
 					return fmt.Errorf("es-test workload data is missing es_monitor_type label: %v", err)
 				}
 				return nil
-			}, util.LongWait)
+			})
 			Expect(err).To(Succeed())
 		})
 	})

--- a/enterprise-suite/gotests/util/util.go
+++ b/enterprise-suite/gotests/util/util.go
@@ -216,27 +216,36 @@ func (cb *CmdBuilder) StopAsync() error {
 	return nil
 }
 
-const maxRepeats = 30
-const firstSleepMs = 20
-const maxSleepMs = 10000
+type WaitTime time.Duration
+
+const (
+	firstSleep = 10 * time.Millisecond
+	maxSleep   = 10 * time.Second
+
+	// Use for operations which are expected to succeed quickly.
+	SmallWait = WaitTime(5 * time.Second)
+	// Use for operations which can take a while to succeed.
+	LongWait = WaitTime(70 * time.Second)
+)
 
 // Repeatedly runs a function, sleeping for a bit after each time, until it returns nil or reaches maxRepeats.
-func WaitUntilSuccess(f func() error) error {
-	sleepTimeMs := firstSleepMs
+func WaitUntilSuccess(f func() error, maxWait WaitTime) error {
+	sleepTime := firstSleep
 	var lastErr error
-	for i := 0; i < maxRepeats; i++ {
+	for endTime := time.Now().Add(time.Duration(maxWait)); time.Now().Before(endTime); {
 		if lastErr = f(); lastErr == nil {
 			return nil
 		}
 		// Exponential backoff
-		sleepTimeMs = sleepTimeMs * 2
-		if sleepTimeMs > maxSleepMs {
-			sleepTimeMs = maxSleepMs
+		sleepTime *= 2
+		if sleepTime > maxSleep {
+			sleepTime = maxSleep
 		}
-		time.Sleep(time.Duration(sleepTimeMs) * time.Millisecond)
+		time.Sleep(sleepTime)
 	}
 
-	return fmt.Errorf("WaitUntilSuccess reached maximum repeats without f() succeeding: %v", lastErr)
+	return fmt.Errorf("WaitUntilSuccess failed: %v", lastErr)
+
 }
 
 func Close(closer io.Closer) {
@@ -247,11 +256,11 @@ func Close(closer io.Closer) {
 }
 
 // Returns a free TCP port on the local machine or an error
-func FindFreePort() (int, error) {
+func FindFreePort() int {
 	conn, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return 0, err
+		panic(fmt.Sprintf("unexpecte error when trying to find free port: %v", err))
 	}
 	defer conn.Close()
-	return conn.Addr().(*net.TCPAddr).Port, nil
+	return conn.Addr().(*net.TCPAddr).Port
 }

--- a/enterprise-suite/gotests/util/util.go
+++ b/enterprise-suite/gotests/util/util.go
@@ -231,7 +231,7 @@ const (
 )
 
 // Repeatedly runs a function, sleeping for a bit after each time, until it returns nil or reaches maxRepeats.
-func WaitUntilSuccess(f func() error, maxWait WaitTime) error {
+func WaitUntilSuccess(maxWait WaitTime, f func() error) error {
 	sleepTime := firstSleep
 	var lastErr error
 	for endTime := time.Now().Add(time.Duration(maxWait)); time.Now().Before(endTime); {

--- a/enterprise-suite/gotests/util/util.go
+++ b/enterprise-suite/gotests/util/util.go
@@ -190,10 +190,12 @@ func (cb *CmdBuilder) Run() error {
 // StartAsync starts the process without waiting for its results. It will check it hasn't immediately died.
 // Use StopAsync() to stop and wait for the results.
 func (cb *CmdBuilder) StartAsync() error {
+	// We should never timeout async processes.
+	cb.NoTimeout()
 	if err := cb.start(); err != nil {
 		return nil
 	}
-	// Check that process hasn't immediately died
+	// Check that process hasn't immediately died.
 	time.Sleep(100 * time.Millisecond)
 	if cb.cmd.ProcessState != nil && cb.cmd.ProcessState.Exited() {
 		return cb.wait(false)


### PR DESCRIPTION
With some additional util improvements:
- Log if the install is taking a while, so it's clear what's going on.
- Make WaitUntilSuccess more configurable, so we don't wait excessively
on failures. Also reduce the max wait to 70s for long waits, from 4
minutes.
- Remove error from FindFreePort - just panic if it fails (which it shouldn't ever).