### PR TITLE
Add redirect to trailing slash

### DIFF
--- a/enterprise-suite/gotests/tests/apiserverproxy/apiserverproxy_test.go
+++ b/enterprise-suite/gotests/tests/apiserverproxy/apiserverproxy_test.go
@@ -2,14 +2,12 @@ package apiserverproxy
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"strconv"
 	"testing"
 
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
-
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/urls"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
 
 	. "github.com/onsi/ginkgo"
@@ -39,24 +37,7 @@ var _ = Describe("all:apiserverproxy", func() {
 		url := fmt.Sprintf("http://127.0.0.1:%d/api/v1/namespaces/%s/services/%s:http/proxy%s",
 			proxyPort, args.ConsoleNamespace, serviceName, servicePath)
 		By(url)
-
-		err := util.WaitUntilSuccess(util.SmallWait, func() error {
-			resp, err := http.Get(url)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return err
-			}
-			if resp.StatusCode != 200 {
-				return fmt.Errorf("wanted 200, got %d: %s", resp.StatusCode, string(body))
-			}
-
-			return nil
-		})
-
+		_, err := urls.Get200(url)
 		Expect(err).ToNot(HaveOccurred())
 	},
 		Entry("console-server", "console-server", "/"),

--- a/enterprise-suite/gotests/tests/apiserverproxy/apiserverproxy_test.go
+++ b/enterprise-suite/gotests/tests/apiserverproxy/apiserverproxy_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/urls"
-	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/enterprise-suite/gotests/tests/nginx/nginx_test.go
+++ b/enterprise-suite/gotests/tests/nginx/nginx_test.go
@@ -1,0 +1,55 @@
+// nginx tests the nginx config rules work as expected.
+package nginx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lightbend/gotests/args"
+	"github.com/lightbend/gotests/testenv"
+	"github.com/lightbend/gotests/util/urls"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+func TestNginxRules(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Nginx Rules Suite")
+}
+
+var _ = BeforeSuite(func() {
+	testenv.InitEnv()
+})
+
+var _ = AfterSuite(func() {
+	testenv.CloseEnv()
+})
+
+var _ = Describe("all:nginx_rules", func() {
+	DescribeTable("returns security headers for console endpoints", func(endpoint string) {
+		res, err := urls.Get200(testenv.ConsoleAddr + endpoint)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.Headers).Should(HaveKeyWithValue("X-Frame-Options", []string{"DENY"}))
+		Expect(res.Headers).Should(HaveKeyWithValue("X-Xss-Protection", []string{"1"}))
+		Expect(res.Headers).Should(HaveKeyWithValue("Content-Security-Policy", []string{"default-src 'self' 'unsafe-eval' 'unsafe-inline';"}))
+		Expect(res.Headers).Should(HaveKeyWithValue("Cache-Control", []string{"no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0"}))
+	},
+		Entry("cluster", "/cluster"),
+		Entry("workloads", fmt.Sprintf("/namespaces/%v/workloads/tiller-deploy", args.TillerNamespace)),
+		Entry("root", ""),
+		Entry("prefix", "/monitoring"),
+		// jsravn: Enable when pipelines is in console image.
+		//Entry("pipelines", "/pipelines"),
+	)
+
+	DescribeTable("should rewrite a missing trailing slash", func(prefix string) {
+		res, err := urls.Get200(testenv.ConsoleAddr + prefix)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res.Body).To(ContainSubstring(`<base href="%v/">`, prefix))
+	},
+		Entry("single subpath", "/monitoring"),
+		Entry("multiple subpaths", "/my/monitoring/prefix"),
+	)
+})

--- a/enterprise-suite/gotests/tests/nginx/nginx_test.go
+++ b/enterprise-suite/gotests/tests/nginx/nginx_test.go
@@ -29,7 +29,9 @@ var _ = AfterSuite(func() {
 
 var _ = Describe("all:nginx_rules", func() {
 	DescribeTable("returns security headers for console endpoints", func(endpoint string) {
-		res, err := urls.Get200(testenv.ConsoleAddr + endpoint)
+		url := testenv.ConsoleAddr + endpoint
+		By(url)
+		res, err := urls.Get200(url)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res.Headers).Should(HaveKeyWithValue("X-Frame-Options", []string{"DENY"}))
 		Expect(res.Headers).Should(HaveKeyWithValue("X-Xss-Protection", []string{"1"}))
@@ -45,7 +47,9 @@ var _ = Describe("all:nginx_rules", func() {
 	)
 
 	DescribeTable("should rewrite a missing trailing slash", func(prefix string) {
-		res, err := urls.Get200(testenv.ConsoleAddr + prefix)
+		url := testenv.ConsoleAddr + prefix
+		By(url)
+		res, err := urls.Get200(url)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res.Body).To(ContainSubstring(`<base href="%v/">`, prefix))
 	},

--- a/enterprise-suite/gotests/tests/nginx/nginx_test.go
+++ b/enterprise-suite/gotests/tests/nginx/nginx_test.go
@@ -35,7 +35,7 @@ var _ = Describe("all:nginx_rules", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res.Headers).Should(HaveKeyWithValue("X-Frame-Options", []string{"DENY"}))
 		Expect(res.Headers).Should(HaveKeyWithValue("X-Xss-Protection", []string{"1"}))
-		Expect(res.Headers).Should(HaveKeyWithValue("Content-Security-Policy", []string{"default-src 'self' 'unsafe-eval' 'unsafe-inline';"}))
+		Expect(res.Headers).Should(HaveKeyWithValue("Content-Security-Policy", []string{"img-src 'self' data:; default-src 'self' 'unsafe-eval' 'unsafe-inline';"}))
 		Expect(res.Headers).Should(HaveKeyWithValue("Cache-Control", []string{"no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0"}))
 	},
 		Entry("cluster", "/cluster"),

--- a/enterprise-suite/gotests/tests/nginx/nginx_test.go
+++ b/enterprise-suite/gotests/tests/nginx/nginx_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/lightbend/gotests/args"
-	"github.com/lightbend/gotests/testenv"
-	"github.com/lightbend/gotests/util/urls"
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/urls"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/enterprise-suite/gotests/util/urls/urls.go
+++ b/enterprise-suite/gotests/util/urls/urls.go
@@ -1,0 +1,40 @@
+package urls
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/lightbend/gotests/util"
+)
+
+type Result struct {
+	Body    string
+	Headers http.Header
+}
+
+// Get200 retries until it gets a 200, otherwise it returns an error.
+func Get200(url string) (Result, error) {
+	var res Result
+
+	err := util.WaitUntilSuccess(util.SmallWait, func() error {
+		resp, err := http.Get(url)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("wanted 200, got %d: %s", resp.StatusCode, string(bodyBytes))
+		}
+
+		res.Body = string(bodyBytes)
+		res.Headers = resp.Header
+		return nil
+	})
+
+	return res, err
+}

--- a/enterprise-suite/gotests/util/urls/urls.go
+++ b/enterprise-suite/gotests/util/urls/urls.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/lightbend/gotests/util"
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
 )
 
 type Result struct {

--- a/enterprise-suite/templates/es-console-configmap.yaml
+++ b/enterprise-suite/templates/es-console-configmap.yaml
@@ -44,12 +44,18 @@ data:
 
       # proxy_pass backends with dynamic base url
 
+      # Location matching strategy:
+      # - Explicit location matchers for each route.
+      # - Anything not matched by the explicit location matchers is treated as a path prefix (base href), added by
+      #   e.g. ingress or apiserver proxy.
+      # - Catch all location matcher is last, which captures the path prefix up to the penultimate slash.
+
       sub_filter_once off;
 
       set $nocache 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
 
       # prometheus UI and api endpoints
-      location ~ (.*/service/prometheus)(/.*) {
+      location ~ ^(.*/service/prometheus)(/.*)$ {
         # encode base path
         array_split '/' $1 to=$encoded_base;
         array_map_op set_escape_uri $encoded_base;
@@ -63,13 +69,13 @@ data:
       }
 
       # es-monitor-api
-      location ~ (.*/service/es-monitor-api)(/.*) {
+      location ~ ^(.*/service/es-monitor-api)(/.*)$ {
         proxy_pass http://$monitorapi$2$is_args$args;
         proxy_redirect '/' ' $1/';
       }
 
       # grafana plugin
-      location ~ (.*/service/grafana)(/dashboard/script/exporter-async.js) {
+      location ~ ^(.*/service/grafana)(/dashboard/script/exporter-async.js)$ {
         # encode base path
         array_split '/' $1 to=$encoded_base;
         array_map_op set_escape_uri $encoded_base;
@@ -90,7 +96,7 @@ data:
       }
 
       # grafana ui
-      location ~ (.*/service/grafana)(/.*) {
+      location ~ ^(.*/service/grafana)(/.*)$ {
         # encode base path
         array_split '/' $1 to=$encoded_base;
         array_map_op set_escape_uri $encoded_base;
@@ -105,7 +111,7 @@ data:
       }
 
       # alertmanager ui
-      location ~ (.*/service/alertmanager)(/.*) {
+      location ~ ^(.*/service/alertmanager)(/.*)$ {
         proxy_pass http://$alertmanager$2$is_args$args;
         proxy_redirect '/' ' $1/';
       }
@@ -114,13 +120,13 @@ data:
       # redirect /service/grafana -> /service/grafana/
       # redirect /service/alertmanager -> /service/alertmanager/
 
-      location ~ (.*/service/(prometheus|grafana|alertmanager))$ {
+      location ~ ^(.*/service/(prometheus|grafana|alertmanager))$ {
         return 301 ' $1/';
       }
 
       # version
 
-      location ~ (.*)/version$ {
+      location ~ ^(.*)/version$ {
         return 200 '{
           "description": {{ .Chart.Description | quote }},
           "version": {{ .Chart.Version | quote }},
@@ -142,7 +148,7 @@ data:
 
       # console entry point
 
-      location ~ (.*/)index.html {
+      location ~ ^(.*/)index.html$ {
         # Console CSP
         add_header Content-Security-Policy $app_csp;
         # encode base path
@@ -164,7 +170,7 @@ data:
       # bookmarks and reloads in the /workloads/ path
       # (for our single page app, these should reload index.html but keep the path)
 
-      location ~ (.*/)(namespaces/[^/]+/workloads/.*) {
+      location ~ ^(.*/)(namespaces/[^/]+/workloads/.*)$ {
         # Console CSP
         add_header Content-Security-Policy $app_csp;
         # encode base path
@@ -186,7 +192,7 @@ data:
 
       # pipelines ui
 
-      location ~ (.*/)(pipelines/.*) {
+      location ~ ^(.*/)(pipelines/.*)$ {
         # Console CSP
         add_header Content-Security-Policy $app_csp;
         # encode base path
@@ -206,16 +212,22 @@ data:
         etag off;
       }
 
-
-      # static files
-
-      location ~ (.*)(/assets/.*) {
+      # Specific handler for assets.
+      location ~ ^(.*)(/assets/.*)$ {
         alias $base$2;
       }
 
-      location ~ (.*)(/.*) {
+      # If there is a single level path with no trailing slash, redirect to trailing slash.
+      # E.g. "http://consoleurl/monitoring" -> 301 to "http://consoleurl/monitoring/".
+      location ~ ^/([^/]+)$ {
+        return 301 $scheme://$host$request_uri/;
+      }
+
+      # Catch all handler that catches "http://consoleurl/prefix1/prefix2/", and redirects to
+      # "http://consoleurl/prefix1/prefix2/index.html". It handles arbitrary number of prefix subpaths.
+      # It does not work with application routes - those need specific location handlers which are listed above.
+      location ~ ^(.*)(/.*)$ {
         root $base;
-        index index.html;
         try_files $2 $1/index.html;
       }
 

--- a/enterprise-suite/templates/es-console-configmap.yaml
+++ b/enterprise-suite/templates/es-console-configmap.yaml
@@ -223,10 +223,10 @@ data:
         try_files $2 $1/index.html;
       }
 
-      # If there is a single level path with no trailing slash, rewrite to trailing slash.
+      # If there is a path with no trailing slash that hasn't matched any location yet, rewrite to trailing slash.
       # E.g. "http://consoleurl/monitoring" -> "http://consoleurl/monitoring/".
-      location ~ ^/[^/]+$ {
-        rewrite ^(/[^/]+)$ $1/ last;
+      location ~ ^/.+[^/]$ {
+        rewrite ^(/.+[^/])$ $1/ last;
       }
 
       # Catch all handler that catches "http://consoleurl/prefix1/prefix2/", and redirects to

--- a/enterprise-suite/templates/es-console-configmap.yaml
+++ b/enterprise-suite/templates/es-console-configmap.yaml
@@ -236,5 +236,4 @@ data:
         root $base;
         try_files $2 $1/index.html;
       }
-
     }

--- a/enterprise-suite/templates/es-console-configmap.yaml
+++ b/enterprise-suite/templates/es-console-configmap.yaml
@@ -217,10 +217,16 @@ data:
         alias $base$2;
       }
 
-      # If there is a single level path with no trailing slash, redirect to trailing slash.
-      # E.g. "http://consoleurl/monitoring" -> 301 to "http://consoleurl/monitoring/".
-      location ~ ^/([^/]+)$ {
-        return 301 $scheme://$host$request_uri/;
+      # Handler for application routes and assets not inside of /assets.
+      location ~ ^(.*)(/(cluster|.*\.js|.*\.css|.*\.woff|.*\.woff2|.*\.ttf))$ {
+        root $base;
+        try_files $2 $1/index.html;
+      }
+
+      # If there is a single level path with no trailing slash, rewrite to trailing slash.
+      # E.g. "http://consoleurl/monitoring" -> "http://consoleurl/monitoring/".
+      location ~ ^/[^/]+$ {
+        rewrite ^(/[^/]+)$ $1/ last;
       }
 
       # Catch all handler that catches "http://consoleurl/prefix1/prefix2/", and redirects to


### PR DESCRIPTION
This change checks for the presence of a single level path without a
trailing slash, and then redirects it.

This should work in all cases, because we already require that all
application routes have specific location blocks to handle them.

Also some other small changes:
- Added anchors to all the regex matches, as recommended by nginx best
practices. This just makes sure we don't match things we shouldn't.
- Dropped 'index index.html' in the final catch-all location block. I
couldn't figure out the point of this, and it didn't seem to have any
effect removing it.

For https://github.com/lightbend/console-backend/issues/598