### PR TITLE
Print debug info in gotests and add k8s annotations

### DIFF
--- a/enterprise-suite/gotests/util/lbc/lbc.go
+++ b/enterprise-suite/gotests/util/lbc/lbc.go
@@ -1,7 +1,11 @@
 package lbc
 
 import (
+	"fmt"
+	"strings"
 	"time"
+
+	"github.com/onsi/ginkgo"
 
 	"github.com/lightbend/gotests/args"
 	"github.com/lightbend/gotests/util"
@@ -14,17 +18,40 @@ func Install(namespace string, additionalArgs ...string) error {
 	defaultArgs := []string{"install", "--local-chart", localChartPath,
 		"--namespace", namespace,
 		"--set prometheusDomain=console-backend-e2e.io",
-		"--wait", "--", "--timeout 520"}
+		"--wait", "--", "--timeout 110"}
 	fullArgs := append(defaultArgs, additionalArgs...)
 	cmd := util.Cmd(lbcPath, fullArgs...)
 	if args.TillerNamespace != "" {
 		cmd = cmd.Env("TILLER_NAMESPACE", args.TillerNamespace)
 	}
-	if err := cmd.Timeout(time.Minute * 6).Run(); err != nil {
+
+	if err := cmd.Timeout(time.Minute * 2).Run(); err != nil {
+		logDebugInfo(namespace)
 		return err
 	}
 
 	return nil
+}
+
+func logDebugInfo(namespace string) {
+	fmt.Fprint(ginkgo.GinkgoWriter, "\n********************************************\nInstall failed, printing debug information:\n\n")
+
+	debugCmds := []string{
+		"get events --sort-by=.metadata.resourceVersion",
+		"logs -lapp.kubernetes.io/name=lightbend-console,app.kubernetes.io/component=es-console --all-containers",
+		"logs -lapp.kubernetes.io/name=lightbend-console,app.kubernetes.io/component=es-console --all-containers -p",
+		"logs -lapp.kubernetes.io/name=lightbend-console,app.kubernetes.io/component=prometheus --all-containers",
+		"logs -lapp.kubernetes.io/name=lightbend-console,app.kubernetes.io/component=prometheus --all-containers -p",
+	}
+
+	for _, cmd := range debugCmds {
+		kubectlArgs := []string{"-n", namespace}
+		kubectlArgs = append(kubectlArgs, strings.Split(cmd, " ")...)
+		if err := util.Cmd("kubectl", kubectlArgs...).PrintCommand().Run(); err != nil {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "Could not gather debug info: %v\n", err)
+		}
+		fmt.Fprintf(ginkgo.GinkgoWriter, "\n")
+	}
 }
 
 func Verify(namespace string) error {

--- a/enterprise-suite/gotests/util/util.go
+++ b/enterprise-suite/gotests/util/util.go
@@ -24,6 +24,7 @@ type CmdBuilder struct {
 	expectZeroExitStatus bool
 	printStdout          bool
 	printStderr          bool
+	printCommand         bool
 	cmd                  *exec.Cmd
 	cancelFunc           context.CancelFunc
 	cmdStdout            io.ReadCloser
@@ -34,12 +35,13 @@ type CmdBuilder struct {
 
 func Cmd(name string, args ...string) *CmdBuilder {
 	return &CmdBuilder{
-		name:        name,
-		args:        args,
-		envVars:     nil,
-		timeout:     DefaultTimeout,
-		printStdout: false,
-		printStderr: false,
+		name:         name,
+		args:         args,
+		envVars:      nil,
+		timeout:      DefaultTimeout,
+		printStdout:  false,
+		printStderr:  false,
+		printCommand: false,
 	}
 }
 
@@ -69,6 +71,12 @@ func (cb *CmdBuilder) PrintOutput() *CmdBuilder {
 	return cb
 }
 
+// PrintCommand will cause the command and its arguments to be printed before it executes.
+func (cb *CmdBuilder) PrintCommand() *CmdBuilder {
+	cb.printCommand = true
+	return cb
+}
+
 func (cb *CmdBuilder) CaptureStdout(out *strings.Builder) *CmdBuilder {
 	cb.captureStdout = out
 	return cb
@@ -91,6 +99,10 @@ func (cb *CmdBuilder) String() string {
 func (cb *CmdBuilder) start() error {
 	if cb.cmd != nil {
 		panic(fmt.Sprintf("%v: attempted to start the same command multiple times", cb))
+	}
+
+	if cb.printCommand {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "%v\n", cb)
 	}
 
 	// Set up timeout context if needed

--- a/enterprise-suite/templates/_helpers.tpl
+++ b/enterprise-suite/templates/_helpers.tpl
@@ -1,3 +1,7 @@
 {{- define "imagePullSecret" }}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.imageCredentials.registry (printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password | b64enc) | b64enc }}
 {{- end }}
+
+{{- define "name" }}
+{{- printf "lightbend-console" }}
+{{- end }}

--- a/enterprise-suite/templates/alertmanager-deployment.yaml
+++ b/enterprise-suite/templates/alertmanager-deployment.yaml
@@ -19,11 +19,18 @@ spec:
     matchLabels:
       app: prometheus
       component: alertmanager
+
   template:
     metadata:
       annotations:
         checksum/alertmanager-config: {{ (.Files.Glob "alertmanager/*").AsConfig | sha256sum }}
       labels:
+        app.kubernetes.io/name: {{ template "name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: alertmanager
+        # Deprecated - these should be removed eventually. Kept to support upgrades with the old labels.
         app: prometheus
         component: alertmanager
     spec:

--- a/enterprise-suite/templates/alertmanager-service.yaml
+++ b/enterprise-suite/templates/alertmanager-service.yaml
@@ -9,7 +9,7 @@ spec:
     port: 9093
     targetPort: 9093
   selector:
-    app: prometheus
-    component: alertmanager
+    app.kubernetes.io/name: {{ template "name" . }}
+    app.kubernetes.io/component: alertmanager
   type: ClusterIP
 {{ end }}

--- a/enterprise-suite/templates/es-console-deployment.yaml
+++ b/enterprise-suite/templates/es-console-deployment.yaml
@@ -3,11 +3,21 @@ kind: Deployment
 metadata:
   name: es-console
 spec:
+  selector:
+    matchLabels:
+      run: es-console
+
   template:
     metadata:
       annotations:
         checksum/es-console-config: {{ include (print $.Template.BasePath "/es-console-configmap.yaml") . | sha256sum }}
       labels:
+        app.kubernetes.io/name: {{ template "name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: es-console
+        # Deprecated - these should be removed eventually. Kept to support upgrades with the old labels.
         run: es-console
     spec:
       {{ if .Values.podUID }}

--- a/enterprise-suite/templates/es-console-expose.yaml
+++ b/enterprise-suite/templates/es-console-expose.yaml
@@ -10,6 +10,7 @@ spec:
     targetPort: 8080
     nodePort: {{ .Values.esConsoleExposePort }}
   selector:
-    run: es-console
+    app.kubernetes.io/name: {{ template "name" . }}
+    app.kubernetes.io/component: es-console
   type: {{ .Values.exposeServices | default "NodePort" }}
 {{ end }}

--- a/enterprise-suite/templates/es-console-service.yaml
+++ b/enterprise-suite/templates/es-console-service.yaml
@@ -8,5 +8,6 @@ spec:
       port: 80
       targetPort: 8080
   selector:
-    run: es-console
+    app.kubernetes.io/name: {{ template "name" . }}
+    app.kubernetes.io/component: es-console
   type: ClusterIP

--- a/enterprise-suite/templates/es-grafana-deployment.yaml
+++ b/enterprise-suite/templates/es-grafana-deployment.yaml
@@ -14,9 +14,20 @@ spec:
     # Needed for helm upgrade to succeed.
     rollingUpdate: null
 
+  selector:
+    matchLabels:
+      app: grafana
+      component: server
+
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: {{ template "name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: grafana
+        # Deprecated - these should be removed eventually. Kept to support upgrades with the old labels.
         app: grafana
         component: server
       annotations:
@@ -24,6 +35,7 @@ spec:
         {{ .Values.prometheusDomain }}/port: "3000"
         checksum/datasource-config: {{ include (print $.Template.BasePath "/es-grafana-configmap-datasource.yaml") . | sha256sum }}
         checksum/plugin-config: {{ (.Files.Glob "es-grafana/*").AsConfig | sha256sum }}
+
     spec:
       {{ if .Values.podUID }}
       securityContext:

--- a/enterprise-suite/templates/es-grafana-service.yaml
+++ b/enterprise-suite/templates/es-grafana-service.yaml
@@ -12,6 +12,6 @@ spec:
       protocol: TCP
       targetPort: 3000
   selector:
-    app: grafana
-    component: "server"
+    app.kubernetes.io/name: {{ template "name" . }}
+    app.kubernetes.io/component: grafana
   type: "ClusterIP"

--- a/enterprise-suite/templates/kube-state-metrics-deployment.yaml
+++ b/enterprise-suite/templates/kube-state-metrics-deployment.yaml
@@ -7,15 +7,24 @@ metadata:
   name: prometheus-kube-state-metrics
 spec:
   replicas: 1
+
   selector:
     matchLabels:
       app: prometheus
       component: kube-state-metrics
+
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: {{ template "name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: kube-state-metrics
+        # Deprecated - these should be removed eventually. Kept to support upgrades with the old labels.
         app: prometheus
         component: kube-state-metrics
+
     spec:
       {{ if .Values.podUID }}
       securityContext:

--- a/enterprise-suite/templates/kube-state-metrics-service.yaml
+++ b/enterprise-suite/templates/kube-state-metrics-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: prometheus-kube-state-metrics
   annotations:
     {{ .Values.prometheusDomain }}/scrape: "true"
   labels:
-    app: prometheus
-    component: "kube-state-metrics"
-  name: prometheus-kube-state-metrics
+    app.kubernetes.io/name: {{ template "name" . }}
+    app.kubernetes.io/component: kube-state-metrics
 spec:
   clusterIP: None
   ports:

--- a/enterprise-suite/templates/prometheus-deployment.yaml
+++ b/enterprise-suite/templates/prometheus-deployment.yaml
@@ -18,15 +18,23 @@ spec:
     matchLabels:
       app: prometheus
       component: server
+
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: {{ template "name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: prometheus
+        # Deprecated - these should be removed eventually. Kept to support upgrades with the old labels.
         app: prometheus
         component: server
       annotations:
         {{ .Values.prometheusDomain }}/scrape: "true"
         checksum/es-monitor-api-config: {{ (.Files.Glob "es-monitor-api/*").AsConfig | sha256sum }}
         checksum/bare-prometheus-config: {{ include (print $.Template.BasePath "/prometheus-configmap-prom.yaml") . | sha256sum }}
+
     spec:
       serviceAccountName: prometheus-server
 

--- a/enterprise-suite/templates/prometheus-service-api.yaml
+++ b/enterprise-suite/templates/prometheus-service-api.yaml
@@ -8,5 +8,5 @@ spec:
       port: 80
       targetPort: 8180
   selector:
-    app: prometheus
-    component: server
+    app.kubernetes.io/name: {{ template "name" . }}
+    app.kubernetes.io/component: prometheus

--- a/enterprise-suite/templates/prometheus-service-prom.yaml
+++ b/enterprise-suite/templates/prometheus-service-prom.yaml
@@ -8,5 +8,5 @@ spec:
       port: 80
       targetPort: 9090
   selector:
-    app: prometheus
-    component: server
+    app.kubernetes.io/name: {{ template "name" . }}
+    app.kubernetes.io/component: prometheus


### PR DESCRIPTION
* Adds the standard kubernetes annotations, useful for the tests to select the correct pods.
* Print debug info when lbc.py fails to install in gotests.
* Reduce install timeout to something more reasonable (2 mins from 6 mins).