### PR TITLE
Add img-src in CSP rule

### DIFF
--- a/enterprise-suite/templates/es-console-configmap.yaml
+++ b/enterprise-suite/templates/es-console-configmap.yaml
@@ -15,7 +15,7 @@ data:
       more_set_headers
         "X-Frame-Options: DENY"
         "X-XSS-Protection: 1";
-      set $app_csp "default-src 'self' 'unsafe-eval' 'unsafe-inline';";
+      set $app_csp "img-src 'self' data:; default-src 'self' 'unsafe-eval' 'unsafe-inline';";
 
       # use external resolver to lookup backends, cache for 30 seconds
 


### PR DESCRIPTION
connect to https://github.com/lightbend/console-frontend/issues/572

Background:
after we set up ingress, we found that the down-arrow image is missing. 
The fix is to bundle down-arrow image in js file
However, CSP complains
<img width="1277" alt="screen shot 2019-02-22 at 11 33 46 am" src="https://user-images.githubusercontent.com/11674700/53266503-c8e52c00-3695-11e9-95a5-181c8c5782ef.png">

This PR is to fix the CSP. 
 down-arrow works with the fix and ingress url (check screenshot)

![screen shot 2019-02-22 at 1 46 10 pm](https://user-images.githubusercontent.com/11674700/53273230-4b76e700-36a8-11e9-9444-0cd3c4dc7260.png)