### PR TITLE
Fix double namespace/srikanth

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -537,7 +537,13 @@ def install(creds_file):
         real_helm_args = args.helm[1:]
         ns_args, unknown = hparser.parse_known_args(real_helm_args)
         if ns_args.namespace != None:
+            if args.namespace != "lightbend" and args.namespace != ns_args.namespace:
+                printerr("WARNING: Conflicting namespace values provided in arguments {} and {} ".format(
+                    args.namespace, ns_args.namespace))
+                printerr("Invoke again with correct namespace value...")
+                fail("Stopping")
             namespace_arg=""
+
         helm_args += ' '.join([arg for arg in real_helm_args]) + ' '
 
     # Add '--set' arguments to helm_args

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -531,10 +531,10 @@ def install(creds_file):
     namespace_arg = "--namespace {}".format(args.namespace)
 
     helm_args = ''
-    if len(args.helm) > 0:
+    if len(args.rest) > 0:
         hparser = argparse.ArgumentParser()
         hparser.add_argument('--namespace')
-        real_helm_args = args.helm[1:]
+        real_helm_args = args.rest[1:]
         try:
             ns_args, unknown = hparser.parse_known_args(real_helm_args)
         except:

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -530,6 +530,7 @@ def install(creds_file):
     version_arg = ('--version ' + args.version) if args.version != None else '--devel'
     namespace_arg = "--namespace {}".format(args.namespace)
 
+    # Handle --namespace in helm args (after --) to complain about conflicts
     helm_args = ''
     if len(args.rest) > 0:
         hparser = argparse.ArgumentParser()
@@ -544,8 +545,7 @@ def install(creds_file):
             if args.namespace != "lightbend" and args.namespace != ns_args.namespace:
                 printerr("WARNING: Conflicting namespace values provided in arguments {} and {} ".format(
                     args.namespace, ns_args.namespace))
-                printerr("Invoke again with correct namespace value...")
-                fail("Stopping")
+                fail("Invoke again with correct namespace value...")
             namespace_arg=""
 
         helm_args += ' '.join([arg for arg in real_helm_args]) + ' '

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -535,11 +535,7 @@ def install(creds_file):
     if len(args.rest) > 0:
         hparser = argparse.ArgumentParser()
         hparser.add_argument('--namespace')
-        real_helm_args = args.rest[1:]
-        try:
-            ns_args, unknown = hparser.parse_known_args(real_helm_args)
-        except:
-            fail("")
+        ns_args, unknown = hparser.parse_known_args(args.rest)
 
         if ns_args.namespace != None:
             if args.namespace != "lightbend" and args.namespace != ns_args.namespace:
@@ -548,7 +544,7 @@ def install(creds_file):
                 fail("Invoke again with correct namespace value...")
             namespace_arg=""
 
-        helm_args += ' '.join([arg for arg in real_helm_args]) + ' '
+        helm_args += ' '.join(args.rest) + ' '
 
     # Add '--set' arguments to helm_args
     if args.set:

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -539,7 +539,7 @@ def install(creds_file):
             args.namespace=args.helm[ns_index+1]
             del args.helm[ns_index:ns_index+2]
 
-        # handle --namspace=<val>
+        # handle --namespace=<val>
         r=re.compile("--namespace=.*")
         if filter(r.match, args.helm):
             ns_val=filter(r.match, args.helm)[0]

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -636,7 +636,6 @@ def install(creds_file):
                 .format(chart_ref, args.helm_name, namespace_arg,
                         version_arg, creds_arg, helm_args))
 
-
 def uninstall(status=None, namespace=None):
     if not status:
         status, namespace = install_status(args.helm_name)

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -538,7 +538,7 @@ def install(creds_file):
         try:
             ns_args, unknown = hparser.parse_known_args(real_helm_args)
         except:
-            fail("Parsing error, invalid namespacein helm args")
+            fail("")
 
         if ns_args.namespace != None:
             if args.namespace != "lightbend" and args.namespace != ns_args.namespace:
@@ -870,7 +870,10 @@ def setup_args(argv):
         subparser.add_argument('--skip-checks', help='skip environment checks',
                                action='store_true')
 
-    args = parser.parse_args(argv)
+    try:
+        args = parser.parse_args(argv)
+    except:
+        fail("")
 
     if len(argv) == 0:
         parser.print_help()

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -855,6 +855,21 @@ def setup_args(argv):
     if len(argv) == 0:
         parser.print_help()
 
+    # namespace can be passed to helm directly after -- and can take format -namespace <value> or --namespace=<value>
+    # remove namespace from helm args and assign it args.namespace
+    # check --namespace foobar
+    if "--namespace" in args.helm and args.helm.index("--namespace") < len(args.helm):
+        ns_index=args.helm.index("--namespace")
+        args.namespace=args.helm[ns_index+1]
+        del args.helm[ns_index:ns_index+2]
+
+    # check --namspace=foobar
+    r=re.compile("--namespace=.*")
+    if filter(r.match, args.helm):
+        ns_val=filter(r.match, args.helm)[0]
+        args.namespace=ns_val.split("=")[1]
+        del(args.helm[args.helm.index(ns_val)])
+
     return args
 
 

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -535,7 +535,11 @@ def install(creds_file):
         hparser = argparse.ArgumentParser()
         hparser.add_argument('--namespace')
         real_helm_args = args.helm[1:]
-        ns_args, unknown = hparser.parse_known_args(real_helm_args)
+        try:
+            ns_args, unknown = hparser.parse_known_args(real_helm_args)
+        except:
+            fail("Parsing error, invalid namespacein helm args")
+
         if ns_args.namespace != None:
             if args.namespace != "lightbend" and args.namespace != ns_args.namespace:
                 printerr("WARNING: Conflicting namespace values provided in arguments {} and {} ".format(

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -6,7 +6,6 @@ import collections
 import tempfile
 import shutil
 import unittest
-from mock import patch
 
 
 # Exception that gets thrown when unexpected command is
@@ -25,14 +24,6 @@ def test_fail(msg):
 
 # A FIFO queue of expected commands will be kept here
 expected_cmds = collections.deque()
-
-
-class MockDevice():
-    """A mock device to temporarily suppress output to stdout
-    Similar to UNIX /dev/null.
-    """
-
-    def write(self, s): pass
 
 # Adds a command to the list
 def expect_cmd(re_pattern, returncode=0, stdout=''):
@@ -234,18 +225,6 @@ class LbcTest(unittest.TestCase):
         with self.assertRaises(TestFailException):
             lbc.main(['install', '--namespace', 'foo', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs',
                       '--', '--set', 'minikube=true', '--fakearg', '--namespace', 'bar'])
-
-    # parseargs fails when there is no namespace argument provided for helm and prints usage, Use mock to supress stderr
-    def test_helm_args_missing_namespace_value_in_args(self):
-        with patch('sys.stderr', new=MockDevice()) as fake_out:
-            with self.assertRaises(TestFailException):
-                lbc.main(['install', '--namespace', '--creds='+self.creds_file,])
-
-    def test_helm_args_missing_namespace_value_in_helm_args(self):
-        with patch('sys.stderr', new=MockDevice()) as fake_out:
-            with self.assertRaises(TestFailException):
-                lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs',
-                '--', '--set', 'minikube=true', '--fakearg', "--namespace"])
 
     def test_helm_set(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -204,27 +204,34 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ minikube=true --fakearg')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --fakearg')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg'])
 
     def test_helm_args_namespace(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ minikube=true --fakearg --namespace=foobar')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ --set minikube=true --fakearg --namespace=foobar')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg', '--namespace=foobar'])
 
     def test_helm_args_namespace_val(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ minikube=true --fakearg --namespace foobar')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ --set minikube=true --fakearg --namespace foobar')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg', '--namespace', 'foobar'])
 
-    def test_helm_args_conflicting_namesapce(self):
+    def test_helm_args_conflicting_namespace(self):
         with self.assertRaises(TestFailException):
             lbc.main(['install', '--namespace', 'foo', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs',
                       '--', '--set', 'minikube=true', '--fakearg', '--namespace', 'bar'])
+    
+    # At some point lbc ate `--timeout` and passed to helm only the number 110
+    def test_helm_args_timeout(self):
+        expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'helm install . --name enterprise-suite --namespace foo --devel --values \S+ --timeout 110 ')
+        lbc.main(['install', '--local-chart', '.', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--namespace', 'foo', '--', '--timeout', '110'])
+
 
     def test_helm_set(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -220,6 +220,11 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ --set minikube=true --fakearg --namespace foobar')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg', '--namespace', 'foobar'])
 
+    def test_helm_args_invalid_namespace_val(self):
+        with self.assertRaises(TestFailException):
+            lbc.main(['install', '--namespace', 'foo', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs',
+                      '--', '--set', 'minikube=true', '--fakearg', '--namespace', 'bar'])
+
     def test_helm_set(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -213,21 +213,21 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --fakearg')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ minikube=true --fakearg')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg'])
 
     def test_helm_args_namespace(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ --set minikube=true --fakearg --namespace=foobar')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ minikube=true --fakearg --namespace=foobar')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg', '--namespace=foobar'])
 
     def test_helm_args_namespace_val(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ --set minikube=true --fakearg --namespace foobar')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ minikube=true --fakearg --namespace foobar')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg', '--namespace', 'foobar'])
 
     def test_helm_args_conflicting_namesapce(self):

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -206,6 +206,20 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --fakearg')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg'])
 
+    def test_helm_args_namespace(self):
+        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
+        expect_cmd(r'helm repo update')
+        expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace foobar --devel --values \S+ --set minikube=true --fakearg')
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg', '--namespace=foobar'])
+
+    def test_helm_args_namespace_val(self):
+        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
+        expect_cmd(r'helm repo update')
+        expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace foobar --devel --values \S+ --set minikube=true --fakearg')
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg', '--namespace', 'foobar'])
+
     def test_helm_set(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -210,14 +210,14 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace foobar --devel --values \S+ --set minikube=true --fakearg')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ --set minikube=true --fakearg --namespace=foobar')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg', '--namespace=foobar'])
 
     def test_helm_args_namespace_val(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace foobar --devel --values \S+ --set minikube=true --fakearg')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite  --devel --values \S+ --set minikube=true --fakearg --namespace foobar')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs', '--', '--set', 'minikube=true', '--fakearg', '--namespace', 'foobar'])
 
     def test_helm_set(self):

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -235,15 +235,12 @@ class LbcTest(unittest.TestCase):
             lbc.main(['install', '--namespace', 'foo', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs',
                       '--', '--set', 'minikube=true', '--fakearg', '--namespace', 'bar'])
 
-    def test_helm_args_missing_namespace_value_in_args(self):
-        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
-        expect_cmd(r'helm repo update')
-        expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace  --devel --values \S+ --set minikube=true --fakearg ')
-        lbc.main(['install', '--namespace', '', '--skip-checks', '--creds='+self.creds_file, '--delete-pvcs',
-                      '--', '--set', 'minikube=true', '--fakearg'])
-
     # parseargs fails when there is no namespace argument provided for helm and prints usage, Use mock to supress stderr
+    def test_helm_args_missing_namespace_value_in_args(self):
+        with patch('sys.stderr', new=MockDevice()) as fake_out:
+            with self.assertRaises(TestFailException):
+                lbc.main(['install', '--namespace', '--creds='+self.creds_file,])
+
     def test_helm_args_missing_namespace_value_in_helm_args(self):
         with patch('sys.stderr', new=MockDevice()) as fake_out:
             with self.assertRaises(TestFailException):

--- a/scripts/setup-tools-for-ubuntu.sh
+++ b/scripts/setup-tools-for-ubuntu.sh
@@ -18,7 +18,7 @@ sudo apt install -y libgconf2-4
 
 # pip mock
 sudo apt-get install -y python-pip
-pip install mock
+sudo pip install mock
 
 # promtool
 mkdir -p build

--- a/scripts/setup-tools-for-ubuntu.sh
+++ b/scripts/setup-tools-for-ubuntu.sh
@@ -16,10 +16,6 @@ sudo apt install -y jq
 # libgconf2-4
 sudo apt install -y libgconf2-4
 
-# pip mock
-sudo apt-get install -y python-pip
-sudo pip install mock
-
 # promtool
 mkdir -p build
 cd build

--- a/scripts/setup-tools-for-ubuntu.sh
+++ b/scripts/setup-tools-for-ubuntu.sh
@@ -16,6 +16,10 @@ sudo apt install -y jq
 # libgconf2-4
 sudo apt install -y libgconf2-4
 
+# pip mock
+sudo apt-get install -y python-pip
+pip install mock
+
 # promtool
 mkdir -p build
 cd build


### PR DESCRIPTION
lightbend/console-backend/issues/596

namespace can be provided as helm arg as --namespace=foobar or --namespace foobar 
Remove  from helm args and populate args.namespace
When I made this changes in setup_args tests failed, so moved the install 

Added two new test cases 