### PR TITLE
Disable go lint for now until it's fixed

### DIFF
--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -24,7 +24,8 @@ vet:
 
 .PHONY: lint
 lint:
-	golint -set_exit_status $(go list ./...)
+	@echo skipping `golint -set_exit_status $(go list ./...)`
+	@echo disabled due to golint being broken on modules
 
 CLEANUP ?= false
 
@@ -42,6 +43,6 @@ format:
 
 .PHONY: setup-tools
 setup-tools:
-	go get -u golang.org/x/lint/golint
+	@echo skipping `go get -u golang.org/x/lint/golint`
 	go get -u golang.org/x/tools/cmd/goimports
 	go get -u github.com/onsi/ginkgo/ginkgo


### PR DESCRIPTION
This is broken in upstream with go modules.

See https://github.com/golang/lint/issues/436