### PR TITLE
lbc.py: require namespace arg for uninstall

### DIFF
--- a/enterprise-suite/gotests/testenv/testenv.go
+++ b/enterprise-suite/gotests/testenv/testenv.go
@@ -168,7 +168,7 @@ func cleanup(allowFailures bool) {
 	}
 
 	// Uninstall Console using helm
-	if err := lbc.Uninstall(); err != nil && !allowFailures {
+	if err := lbc.Uninstall(args.ConsoleNamespace); err != nil && !allowFailures {
 		Expect(err).To(Succeed(), "lbc.Uninstall")
 	}
 

--- a/enterprise-suite/gotests/util/lbc/lbc.go
+++ b/enterprise-suite/gotests/util/lbc/lbc.go
@@ -66,8 +66,8 @@ func Verify(namespace string) error {
 	return nil
 }
 
-func Uninstall() error {
-	cmd := util.Cmd(lbcPath, "uninstall")
+func Uninstall(namespace string) error {
+	cmd := util.Cmd(lbcPath, "uninstall", "--namespace", namespace)
 	if args.TillerNamespace != "" {
 		cmd = cmd.Env("TILLER_NAMESPACE", args.TillerNamespace)
 	}

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -553,6 +553,9 @@ def install(creds_file):
 def uninstall(status=None):
     if status == None:
         status, namespace = install_status(args.helm_name)
+        if namespace != args.namespace:
+            fail('Unable to delete console installation - released named {} found in namespace {}, expected in {}'
+                 .format(args.helm_name, namespace, args.namespace))
 
     if status == 'notfound':
         fail('Unable to delete console installation - no release named {} found'.format(args.helm_name))
@@ -560,7 +563,7 @@ def uninstall(status=None):
         fail('Unable to delete console installation {} - it is already being deleted'.format(args.helm_name))
     else:
         if not args.delete_pvcs:
-            check_pv_usage(aboutToUninstall=True, namespace=namespace)
+            check_pv_usage(aboutToUninstall=True, namespace=args.namespace)
 
         printerr("info: deleting previous console installation {} with status '{}'".format(args.helm_name, status))
         execute('helm delete --purge ' + args.helm_name)
@@ -766,13 +769,10 @@ def setup_args(argv):
                                action='store_true')
         subparser.add_argument('--helm-name', help='helm release name', default='enterprise-suite')
 
-    # Common arguments for install, verify and dump
-    for subparser in [install, verify, debug_dump]:
-        subparser.add_argument('--namespace', help='namespace to install console into/where it is installed',
-                               default='lightbend')
-
     # Common arguments for all subparsers
     for subparser in [install, uninstall, verify, debug_dump]:
+        subparser.add_argument('--namespace', help='namespace to install console into/where it is installed',
+                               default='lightbend')
         subparser.add_argument('--skip-checks', help='skip environment checks',
                                action='store_true')
 

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -554,7 +554,7 @@ def uninstall(status=None):
     if status == None:
         status, namespace = install_status(args.helm_name)
         if namespace != args.namespace:
-            fail('Unable to delete console installation - released named {} found in namespace {}, expected in {}'
+            fail('Unable to delete console installation - release named {} found in namespace {}, expected in {}'
                  .format(args.helm_name, namespace, args.namespace))
 
     if status == 'notfound':


### PR DESCRIPTION
For https://github.com/lightbend/console-backend/issues/622

This should fix the bug where `namespace` variable was being used without initialization. Also, this PR adds `--namespace` argument for `uninstall` subcommand.

I always found it odd that most subcommands (`install`, `verify`, `debug-dump`) had `--namespace` argument, but `uninstall` did not. That comes from `helm delete` which takes release name and doesn't need namespace. Now lbc.py will not have this inconsistency and will check if given namespace is the same as where helm release is installed.