### PR TITLE
Get PV info from PVCs/StorageClass info if needed (e.g. for OpenShift).

### DIFF
--- a/enterprise-suite/gotests/testenv/testenv.go
+++ b/enterprise-suite/gotests/testenv/testenv.go
@@ -3,6 +3,7 @@ package testenv
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
@@ -64,6 +65,7 @@ func InitEnv() {
 		Expect(err).To(Succeed(), "new k8sclient")
 	}
 
+	additionalLbcArgs := []string{}
 	additionalArgs := []string{"--set esConsoleURL=http://console.test.bogus:30080"}
 	if isMinikube {
 		additionalArgs = append(additionalArgs, "--set exposeServices=NodePort")
@@ -78,8 +80,10 @@ func InitEnv() {
 				break
 			}
 		}
-		if !foundStorageClass {
-			additionalArgs = append(additionalArgs, "--set usePersistentVolumes=false,managePersistentVolumes=false")
+		if foundStorageClass {
+			additionalLbcArgs = append(additionalLbcArgs, "--delete-pvcs")
+		} else {
+			additionalArgs = append(additionalArgs, "--set usePersistentVolumes=false")
 		}
 	}
 
@@ -106,7 +110,7 @@ func InitEnv() {
 	defer ticker.Stop()
 
 	// Install console
-	if err := lbc.Install(args.ConsoleNamespace, additionalArgs...); err != nil {
+	if err := lbc.Install(args.ConsoleNamespace, strings.Join(additionalLbcArgs, " "), additionalArgs...); err != nil {
 		Expect(err).To(Succeed(), "lbc.Install")
 	}
 

--- a/enterprise-suite/gotests/util/lbc/lbc.go
+++ b/enterprise-suite/gotests/util/lbc/lbc.go
@@ -14,11 +14,13 @@ import (
 const localChartPath = "../../../."
 const lbcPath = "../../../scripts/lbc.py"
 
-func Install(namespace string, additionalArgs ...string) error {
+func Install(namespace string, additionalLbcArgs string, additionalArgs ...string) error {
 	defaultArgs := []string{"install", "--local-chart", localChartPath,
 		"--namespace", namespace,
 		"--set prometheusDomain=console-backend-e2e.io",
-		"--wait", "--", "--timeout 110"}
+		"--wait",
+		additionalLbcArgs,
+		"--", "--timeout 110"}
 	fullArgs := append(defaultArgs, additionalArgs...)
 	cmd := util.Cmd(lbcPath, fullArgs...)
 	if args.TillerNamespace != "" {
@@ -67,7 +69,7 @@ func Verify(namespace string) error {
 }
 
 func Uninstall() error {
-	cmd := util.Cmd(lbcPath, "uninstall")
+	cmd := util.Cmd(lbcPath, "uninstall", "--delete-pvcs")
 	if args.TillerNamespace != "" {
 		cmd = cmd.Env("TILLER_NAMESPACE", args.TillerNamespace)
 	}

--- a/enterprise-suite/gotests/util/lbc/lbc.go
+++ b/enterprise-suite/gotests/util/lbc/lbc.go
@@ -22,6 +22,7 @@ func Install(namespace string, additionalLbcArgs string, additionalArgs ...strin
 		additionalLbcArgs,
 		"--", "--timeout 110"}
 	fullArgs := append(defaultArgs, additionalArgs...)
+	logDebugInfo(fmt.Sprintf("invoking: lbc.py %s %s", lbcPath, fullArgs))
 	cmd := util.Cmd(lbcPath, fullArgs...)
 	if args.TillerNamespace != "" {
 		cmd = cmd.Env("TILLER_NAMESPACE", args.TillerNamespace)


### PR DESCRIPTION
The `lbc.py` logic to help avert accidental data loss currently depend on getting PV info from k8s.  Turns out that a typical user won't have access to this info on OpenShift.  We need a way to cope with this on OpenShift.

These changes get as much PV information as they can on OpenShift from other sources.