### PR TITLE
Add scripts/ to helmignore so that it doesn't end up in charts tarball

### DIFF
--- a/enterprise-suite/.helmignore
+++ b/enterprise-suite/.helmignore
@@ -28,5 +28,6 @@ README.md
 \#
 tests/
 gotests/
+scripts/
 .vscode/
 .venv/


### PR DESCRIPTION
This will remove the following files from our next helm chart releases:

```
enterprise-suite-latest/scripts/install-es.sh
enterprise-suite-latest/scripts/lbc.py
enterprise-suite-latest/scripts/lbc_test.py
enterprise-suite-latest/scripts/pipelines.yaml
enterprise-suite-latest/scripts/run-e2e-tests.sh
enterprise-suite-latest/scripts/validate-promql.sh
```