### PR TITLE
Spark workloads

### DIFF
--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -81,6 +81,11 @@ scrape_configs:
       - source_labels: [kubernetes_pod_name, es_workload]
         regex: (.*)-[bcdfghjklmnpqrstvwxz2456789]{5};
         target_label: es_workload
+      # spark executor workload
+      - source_labels: [kubernetes_pod_name, es_workload]
+        regex: (.*)-[0-9]{13}-exec-[0-9]{1,3};
+        replacement: ${1}-exec
+        target_label: es_workload
       # extract workload from workload-num
       - source_labels: [kubernetes_pod_name, es_workload]
         regex: (.*)-[0-9]{1,4};
@@ -182,6 +187,11 @@ scrape_configs:
       - source_labels: [pod, es_workload]
         regex: (.*)-[bcdfghjklmnpqrstvwxz2456789]{5};
         target_label: es_workload
+      # spark executor workload
+      - source_labels: [kubernetes_pod_name, es_workload]
+        regex: (.*)-[0-9]{13}-exec-[0-9]{1,3};
+        replacement: ${1}-exec
+        target_label: es_workload
       # extract workload from workload-num
       - source_labels: [pod, es_workload]
         regex: (.*)-[0-9]{1,4};
@@ -273,6 +283,15 @@ scrape_configs:
         action: replace
         regex: '(.*)-[0-9]+;'
         target_label: es_workload
+      # spark executor workload
+      - source_labels: [kubernetes_pod_name, es_workload]
+        regex: (.*)-[0-9]{13}-exec-[0-9]{1,3};
+        replacement: ${1}-exec
+        target_label: es_workload
+      # fall through plain pod name
+      - source_labels: [kubernetes_pod_name, es_workload]
+        regex: (.*);
+        target_label: es_workload
 
 {{ .MonitorTypeRules | indent 6 }}
 
@@ -351,6 +370,17 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_label_statefulset_kubernetes_io_pod_name, es_workload]
         action: replace
         regex: '(.*)-[0-9]+;'
+        target_label: es_workload
+
+      # spark executor workload
+      - source_labels: [kubernetes_pod_name, es_workload]
+        regex: (.*)-[0-9]{13}-exec-[0-9]{1,3};
+        replacement: ${1}-exec
+        target_label: es_workload
+
+      # fall through plain pod name
+      - source_labels: [kubernetes_pod_name, es_workload]
+        regex: (.*);
         target_label: es_workload
 
 {{ .MonitorTypeRules | indent 6 }}

--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -188,7 +188,7 @@ scrape_configs:
         regex: (.*)-[bcdfghjklmnpqrstvwxz2456789]{5};
         target_label: es_workload
       # spark executor workload
-      - source_labels: [kubernetes_pod_name, es_workload]
+      - source_labels: [pod, es_workload]
         regex: (.*)-[0-9]{13}-exec-[0-9]{1,3};
         replacement: ${1}-exec
         target_label: es_workload

--- a/enterprise-suite/scripts/pipelines.yaml
+++ b/enterprise-suite/scripts/pipelines.yaml
@@ -1,3 +1,3 @@
-esConsoleImage: lightbend-docker-commercial-registry.bintray.io/enterprise-suite/paullines-ui
+esConsoleImage: lightbend-docker-commercial-registry.bintray.io/enterprise-suite/pipelines-ui
 esConsoleVersion: latest
 imagePullPolicy: Always

--- a/enterprise-suite/scripts/pipelines.yaml
+++ b/enterprise-suite/scripts/pipelines.yaml
@@ -1,3 +1,3 @@
-esConsoleImage: lightbend-docker-commercial-registry.bintray.io/enterprise-suite/pipelines-ui
+esConsoleImage: lightbend-docker-commercial-registry.bintray.io/enterprise-suite/paullines-ui
 esConsoleVersion: latest
 imagePullPolicy: Always


### PR DESCRIPTION
Spark workloads were not being labeled correctly or consistently, in main because they're bare pods. Because the pod names end in "-1" they accidentally match some of our StatefulSet rules, and in other places because they are bare pods there is no template-hash to guide naming convention and as a result no name would be applied at all, effectively making pod data invisible to Console.

While we're in here, we can normalize the Executor workload names, as those pod names have timestamps and instance IDs built into them, which are not suitable for stable IDs needed for monitoring. The bug there is if someone defined a monitor, it would unapply when Spark moved the pod because the timestamp and/or instance IDs would move.

After this change, we have consistent naming as well as a working join across container, jvm, kafka_consumer, kube_pod, and spark_executor data sets:

![image](https://user-images.githubusercontent.com/1753336/53930388-f2169c80-4045-11e9-899c-4cbcc5408977.png)

This is deployed in the zandvoort cluster if anyone wants to go poke at prometheus to see how things look.

http://console-server-lightbend.zandvoort.lightbend.com/service/prometheus/graph?g0.range_input=1h&g0.expr=count%20by%20(es_workload)%20(%7Bspark_role!%3D%22%22%7D)&g0.tab=1

Fixes https://github.com/lightbend/console-backend/issues/632