### PR TITLE
kafka monitors suitable for pipelines clients

### DIFF
--- a/enterprise-suite/console-api/default-monitors.json
+++ b/enterprise-suite/console-api/default-monitors.json
@@ -680,6 +680,59 @@
           "summary": "Circuit breaker tripped",
           "description": "Circuit breaker {{$labels.circuit_breaker}} tripped on {{$labels.instance}}"
         }
+      },
+      "kafka_consumer_throughput": {
+        "monitorVersion": "1",
+        "model": "sma",
+        "parameters": {
+          "metric": "kafka_consumer_topic_consumed_rate",
+          "period": "15m",
+          "minval": "1000",
+          "window": "15m",
+          "confidence": "1",
+          "severity": {
+            "warning": {
+              "numsigma": "3"
+            }
+          },
+          "summary": "Kafka consumer throughput is anomalous",
+          "description": "{{$labels.es_workload}} has unusual throughput on {{$labels.topic}}"
+        }
+      },
+      "kafka_producer_throughput": {
+        "monitorVersion": "1",
+        "model": "sma",
+        "parameters": {
+          "metric": "kafka_producer_topic_send_rate",
+          "period": "15m",
+          "minval": "1000",
+          "window": "15m",
+          "confidence": "1",
+          "severity": {
+            "warning": {
+              "numsigma": "3"
+            }
+          },
+          "summary": "Kafka producer throughput is anomalous",
+          "description": "{{$labels.es_workload}} has unusual throughput on {{$labels.topic}}"
+        }
+      },
+      "kafka_consumer_lag": {
+        "monitorVersion": "1",
+        "model": "growth",
+        "parameters": {
+          "metric": "kafka_consumer_topic_lag_max",
+          "period": "15m",
+          "minslope": "0.1",
+          "confidence": "1",
+          "severity": {
+            "warning": {
+              "window": "15m"
+            }
+          },
+          "summary": "consumergroup falling behind",
+          "description": "{{$labels.es_workload}} has lag on {{$labels.topic}}"
+        }
       }
     }
   }

--- a/enterprise-suite/console-api/static-rules.yml
+++ b/enterprise-suite/console-api/static-rules.yml
@@ -64,3 +64,12 @@
 
 - record: akka_http_http_server_responses_5xx_rate
   expr: irate(akka_http_http_server_responses_5xx[5m]) and akka_http_http_server_responses_5xx offset 1m
+
+- record: kafka_consumer_topic_consumed_rate
+  expr: sum by (app_kubernetes_io_component, app_kubernetes_io_managed_by, app_kubernetes_io_name, app_kubernetes_io_part_of, es_monitor_type, es_workload, namespace, topic) (kafka_consumer_consumer_fetch_manager_metrics_records_consumed_rate)
+
+- record: kafka_producer_topic_send_rate
+  expr: sum by (app_kubernetes_io_component, app_kubernetes_io_managed_by, app_kubernetes_io_name, app_kubernetes_io_part_of, es_monitor_type, es_workload, namespace, topic) (kafka_producer_producer_metrics_record_send_rate)
+
+- record: kafka_consumer_topic_lag_max
+  expr: max by (app_kubernetes_io_component, app_kubernetes_io_managed_by, app_kubernetes_io_name, app_kubernetes_io_part_of, es_monitor_type, es_workload, namespace, topic, instance) (kafka_consumer_consumer_fetch_manager_metrics_records_lag_max >= 0)


### PR DESCRIPTION
fixes https://github.com/lightbend/console-backend/issues/631

Provides pre-aggregated throughput and lag metrics (since Console UI cannot handle aggregation section in a monitor). The metrics all come from vanilla kafka client metrics which only have a `topic` dimension. We include various context tags for the workload kind of scope, and for lag we include an instance tag. Note that throughput is aggregated across partitions and modeled as a grand total, so we are not flagging or catching throughput changes at the partition or instance level. For lag however we have max over window and max over instance is sensible, so we retain the instance distinction.

The Pipelines UI uses `app_kubernetes_io_name` and `topic` to join into other data sets, so inlet and outlet metadata may be added.

Otherwise these are just conservative 15 minute sma and growth monitors, nothing unusual. We may tune them later.

One can see them in action in the zandvoort cluster:

http://console-server-lightbend.zandvoort.lightbend.com/cluster

http://console-server-lightbend.zandvoort.lightbend.com/namespaces/app-call-record-pipeline/workloads/call-record-pipeline-cdr-aggregator-exec