### PR TITLE
increase frontend e2e test polling time

### DIFF
--- a/enterprise-suite/scripts/run-e2e-tests.sh
+++ b/enterprise-suite/scripts/run-e2e-tests.sh
@@ -21,13 +21,13 @@ cd $script_dir/../tests/e2e
 # run the e2e test
 set +e
 
-npm install
+npm run e2e:demo-app-setup
 if [[ "$?" != "0" ]]; then
     diagnostics
     exit 1
 fi
 
-npm run e2e:demo-app-setup
+npm install
 if [[ "$?" != "0" ]]; then
     diagnostics
     exit 1

--- a/enterprise-suite/tests/e2e/cypress/integration/create-monitor.spec.ts
+++ b/enterprise-suite/tests/e2e/cypress/integration/create-monitor.spec.ts
@@ -13,8 +13,7 @@ describe('Create Monitor Test', () => {
 
 
   // NOTE: group by actor is flaky due to the following two issues
-  // FIXME: SKIP the test due to flaky
-  it.skip('validate created threshold monitor w/ group by actor', () => {
+  it('validate created threshold monitor w/ group by actor', () => {
     // create and save monitor
     const monitorName = Util.createRandomMonitorName();
     Navigation.goWorkloadPageByClick('es-demo');

--- a/enterprise-suite/tests/e2e/cypress/support/util.ts
+++ b/enterprise-suite/tests/e2e/cypress/support/util.ts
@@ -25,15 +25,15 @@ export class Util {
   }
 
   static validateMidHealthBarCount(count: number) {
-    cy.get('.list-header', {timeout: 20000}).should('have.text', `Groupings (${count})`);
+    cy.get('.list-header', {timeout: 35000}).should('have.text', `Groupings (${count})`);
   }
 
   static validateUrlPath(urlPath: string) {
-    cy.location('pathname', {timeout: 20000}).should('eq', urlPath);
+    cy.location('pathname', {timeout: 35000}).should('eq', urlPath);
   }
 
   static validateMonitorCountGte(count: number) {
-    cy.get('.monitor-list .monitor-name', {timeout: 10000}).should('have.length.be.gte', count);
+    cy.get('.monitor-list .monitor-name', {timeout: 20000}).should('have.length.be.gte', count);
   }
 
   static validateControlIconContains(value: string) {

--- a/enterprise-suite/tests/e2e/package.json
+++ b/enterprise-suite/tests/e2e/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "e2e": "cypress run",
     "e2e:minikube": "cypress run --env configFile=minikube",
-    "e2e:travis-prs": "NO_COLOR=1 cypress run --env configFile=minikube,skipKnownError=true",
+    "e2e:travis-prs": "NO_COLOR=1 cypress-run --env configFile=minikube",
     "e2e:travis-prs-subset1": "NO_COLOR=1 cypress-run --spec 'cypress/integration/+(cluster-page|grafana|monitor-history|workload-page).spec.ts' --env configFile=minikube",
     "e2e:travis-prs-subset2": "NO_COLOR=1 cypress-run --spec 'cypress/integration/+(create-monitor|local-prom-health).spec.ts' --env configFile=minikube",
     "e2e:travis-prs:result": "NO_COLOR=1 cypress-run --env configFile=minikube,skipKnownError=true | tee results.txt",


### PR DESCRIPTION
several changes in frontend e2e test
1. increase polling time
2. enable test in create-monitor.spec.ts
3. install es-demo earlier to have more time to generate metric