### PR TITLE
handle both jmx_exporter and cinnamon jvm metrics

### DIFF
--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -46,7 +46,7 @@ frontend-tests: ## Run all the frontend tests against minikube
 	$(CHART_DIR)/scripts/run-e2e-tests.sh
 
 .PHONY: frontend-tests1
-frontend-tests1: ## Run subset 1 of frontend tests against minikube 
+frontend-tests1: ## Run subset 1 of frontend tests against minikube
 	$(CHART_DIR)/scripts/run-e2e-tests.sh 1
 
 .PHONY: frontend-tests2
@@ -72,7 +72,7 @@ lint-helm:  ## Run helm lint on chart files
 
 .PHONY: lint-json
 lint-json:  ## Test json files are well-formed
-	find $(CHART_DIR) -not -path '*/\.*' -name '*.json' | xargs -tn 1 jq . >/dev/null
+	find $(CHART_DIR)/console-api $(CHART_DIR)/es-grafana -name '*.json' | xargs -tn 1 jq . >/dev/null
 
 .PHONY: lint-promql
 lint-promql:  ## Test promql bits are well-formed

--- a/enterprise-suite/es-grafana/jvm-exporter.json
+++ b/enterprise-suite/es-grafana/jvm-exporter.json
@@ -3,19 +3,19 @@
     "graphName": "Heap",
     "promQL": [
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_heap_committed{ContextTags})",
+        "expr": "jvm_memory_bytes_committed{ContextTags,area=\"heap\"} or on (kubernetes_pod_name) jvm_heap_committed{ContextTags}",
         "legendFormat": "committed {{kubernetes_pod_name}}"
       },
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_heap_init{ContextTags})",
+        "expr": "jvm_memory_bytes_init{ContextTags,area=\"heap\"} or on (kubernetes_pod_name) jvm_heap_init{ContextTags}",
         "legendFormat": "init {{kubernetes_pod_name}}"
       },
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_heap_max{ContextTags})",
+        "expr": "jvm_memory_bytes_max{ContextTags,area=\"heap\"} or on (kubernetes_pod_name) jvm_heap_max{ContextTags}",
         "legendFormat": "max {{kubernetes_pod_name}}"
       },
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_heap_used{ContextTags})",
+        "expr": "jvm_memory_bytes_used{ContextTags,area=\"heap\"} or on (kubernetes_pod_name) jvm_heap_used{ContextTags}",
         "legendFormat": "used {{kubernetes_pod_name}}"
       }
     ],
@@ -27,19 +27,19 @@
     "graphName": "Non Heap",
     "promQL": [
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_non_heap_committed{ContextTags})",
+        "expr": "jvm_memory_bytes_committed{ContextTags,area=\"nonheap\"} or on (kubernetes_pod_name) jvm_non_heap_committed{ContextTags}",
         "legendFormat": "commmitted {{kubernetes_pod_name}}"
       },
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_non_heap_init{ContextTags})",
+        "expr": "jvm_memory_bytes_init{ContextTags,area=\"nonheap\"} or on (kubernetes_pod_name)jvm_non_heap_init{ContextTags}",
         "legendFormat": "init {{kubernetes_pod_name}}"
       },
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_non_heap_max{ContextTags})",
+        "expr": "jvm_memory_bytes_max{ContextTags,area=\"nonheap\"} or on (kubernetes_pod_name)jvm_non_heap_max{ContextTags}",
         "legendFormat": "max {{kubernetes_pod_name}}"
       },
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_non_heap_used{ContextTags})",
+        "expr": "jvm_memory_bytes_used{ContextTags,area=\"nonheap\"} or on (kubernetes_pod_name)jvm_non_heap_used{ContextTags}",
         "legendFormat": "used {{kubernetes_pod_name}}"
       }
     ],
@@ -51,19 +51,19 @@
     "graphName": "Total Memory",
     "promQL": [
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_total_committed{ContextTags})",
+        "expr": "sum by (kubernetes_pod_name) (jvm_memory_bytes_committed{ContextTags}) or on (kubernetes_pod_name) jvm_total_committed{ContextTags}",
         "legendFormat": "committed {{kubernetes_pod_name}}"
       },
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_total_init{ContextTags})",
+        "expr": "sum by (kubernetes_pod_name) (jvm_memory_bytes_init{ContextTags}) or on (kubernetes_pod_name) jvm_total_init{ContextTags}",
         "legendFormat": "init {{kubernetes_pod_name}}"
       },
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_total_max{ContextTags})",
+        "expr": "sum by (kubernetes_pod_name) (jvm_memory_bytes_max{ContextTags}) or on (kubernetes_pod_name) jvm_total_max{ContextTags}",
         "legendFormat": "max {{kubernetes_pod_name}}"
       },
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_total_used{ContextTags})",
+        "expr": "sum by (kubernetes_pod_name) (jvm_memory_bytes_used{ContextTags}) or on (kubernetes_pod_name) jvm_total_used{ContextTags}",
         "legendFormat": "used {{kubernetes_pod_name}}"
       }
     ],
@@ -75,37 +75,35 @@
     "graphName": "GC Rate",
     "promQL": [
       {
-        "expr": "sum by (kubernetes_pod_name)(rate(jvm_PS_MarkSweep_count{ContextTags}[5m]))",
-        "legendFormat": "PS_MarkSweep Rate {{kubernetes_pod_name}}"
-      },
-      {
-        "expr": "sum by (kubernetes_pod_name)(rate(jvm_PS_Scavenge_count{ContextTags}[5m]))",
-        "legendFormat": "PS_Scavenge Rate {{kubernetes_pod_name}}"
+        "expr": "rate( (jvm_gc_collection_seconds_count{ContextTags} or on (kubernetes_pod_name, gc) label_replace({ContextTags,__name__=~\"jvm_.*_count\",gc=\"\"}, \"gc\", \"$1\", \"__name__\", \"jvm_(.*)_count\")) [5m:])",
+        "legendFormat": "{{gc}} rate {{kubernetes_pod_name}}"
       }
-    ]
+    ],
+    "yaxes": {
+      "format": "ops"
+    }
   },
   {
     "graphName": "GC Time",
     "promQL": [
       {
-        "expr": "max by (kubernetes_pod_name)(jvm_PS_MarkSweep_time{ContextTags})",
-        "legendFormat": "PS_MarkSweep max {{kubernetes_pod_name}}"
-      },
-      {
-        "expr": "max by (kubernetes_pod_name)(jvm_PS_Scavenge_time{ContextTags})",
-        "legendFormat": "PS_Scavenge max {{kubernetes_pod_name}}"
+        "expr": "rate( (jvm_gc_collection_seconds_sum{ContextTags} or on (kubernetes_pod_name, gc) label_replace({ContextTags,__name__=~\"jvm_.*_time\",gc=\"\"}, \"gc\", \"$1\", \"__name__\", \"jvm_(.*)_time\") /1000) [5m:])",
+        "legendFormat": "{{gc}} time {{kubernetes_pod_name}}"
       }
-    ]
+    ],
+    "yaxes": {
+      "format": "s"
+    }
   },
   {
     "graphName": "Class Loading",
     "promQL": [
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_loaded{ContextTags})",
+        "expr": "jvm_classes_loaded{ContextTags} or on (kubernetes_pod_name) jvm_loaded{ContextTags}",
         "legendFormat": "loaded {{kubernetes_pod_name}}"
       },
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_unloaded{ContextTags})",
+        "expr": "jvm_classes_unloaded{ContextTags} or on (kubernetes_pod_name) jvm_unloaded{ContextTags}",
         "legendFormat": "unloaded {{kubernetes_pod_name}}"
       }
     ]
@@ -114,24 +112,8 @@
     "graphName": "Memory Pool Usage",
     "promQL": [
       {
-        "expr": "sum by (kubernetes_pod_name)(jvm_pools_Code_Cache_usage{ContextTags})",
-        "legendFormat": "Code Cache {{kubernetes_pod_name}}"
-      },
-      {
-        "expr": "sum by (kubernetes_pod_name)(jvm_pools_Compressed_Class_Space_usage{ContextTags})",
-        "legendFormat": "Compressed Class Space {{kubernetes_pod_name}}"
-      },
-      {
-        "expr": "sum by (kubernetes_pod_name)(jvm_pools_PS_Eden_Space_usage{ContextTags})",
-        "legendFormat": "PS Eden Space {{kubernetes_pod_name}}"
-      },
-      {
-        "expr": "sum by (kubernetes_pod_name)(jvm_pools_PS_Old_Gen_usage{ContextTags})",
-        "legendFormat": "PS Old Gen {{kubernetes_pod_name}}"
-      },
-      {
-        "expr": "sum by (kubernetes_pod_name)(jvm_pools_PS_Survivor_Space_usage{ContextTags})",
-        "legendFormat": "PS Survivor Space {{kubernetes_pod_name}}"
+        "expr": "jvm_memory_pool_bytes_used / jvm_memory_pool_bytes_max > 0 or on (kubernetes_pod_name) label_replace({__name__=~\"jvm_pools_.*_usage\",__name__!=\"jvm_pools_Metaspace_usage\"}, \"pool\", \"$1\", \"__name__\", \"jvm_pools_(.*)_usage\")",
+        "legendFormat": "{{pool}} on {{kubernetes_pod_name}}"
       }
     ],
     "yaxes": {

--- a/enterprise-suite/es-grafana/jvm-exporter.json
+++ b/enterprise-suite/es-grafana/jvm-exporter.json
@@ -112,7 +112,7 @@
     "graphName": "Memory Pool Usage",
     "promQL": [
       {
-        "expr": "jvm_memory_pool_bytes_used / jvm_memory_pool_bytes_max > 0 or on (kubernetes_pod_name) label_replace({__name__=~\"jvm_pools_.*_usage\",__name__!=\"jvm_pools_Metaspace_usage\"}, \"pool\", \"$1\", \"__name__\", \"jvm_pools_(.*)_usage\")",
+        "expr": "jvm_memory_pool_bytes_used{ContextTags} / jvm_memory_pool_bytes_max{ContextTags} > 0 or on (kubernetes_pod_name) label_replace({ContextTags,__name__=~\"jvm_pools_.*_usage\",__name__!=\"jvm_pools_Metaspace_usage\"}, \"pool\", \"$1\", \"__name__\", \"jvm_pools_(.*)_usage\")",
         "legendFormat": "{{pool}} on {{kubernetes_pod_name}}"
       }
     ],

--- a/enterprise-suite/es-grafana/jvm-exporter.json
+++ b/enterprise-suite/es-grafana/jvm-exporter.json
@@ -72,7 +72,7 @@
     }
   },
   {
-    "graphName": "GC Rate",
+    "graphName": "GC Rate (avg per second)",
     "promQL": [
       {
         "expr": "rate( (jvm_gc_collection_seconds_count{ContextTags} or on (kubernetes_pod_name, gc) label_replace({ContextTags,__name__=~\"jvm_.*_count\",gc=\"\"}, \"gc\", \"$1\", \"__name__\", \"jvm_(.*)_count\")) [5m:])",
@@ -84,7 +84,7 @@
     }
   },
   {
-    "graphName": "GC Time",
+    "graphName": "GC Time (avg per second)",
     "promQL": [
       {
         "expr": "rate( (jvm_gc_collection_seconds_sum{ContextTags} or on (kubernetes_pod_name, gc) label_replace({ContextTags,__name__=~\"jvm_.*_time\",gc=\"\"}, \"gc\", \"$1\", \"__name__\", \"jvm_(.*)_time\") /1000) [5m:])",

--- a/scripts/setup-tools-for-ubuntu.sh
+++ b/scripts/setup-tools-for-ubuntu.sh
@@ -19,10 +19,10 @@ sudo apt install -y libgconf2-4
 # promtool
 mkdir -p build
 cd build
-prom_version=2.3.2
+prom_version=2.7.2
 prom_file="prometheus-${prom_version}.linux-amd64.tar.gz"
 curl -LO https://github.com/prometheus/prometheus/releases/download/v${prom_version}/${prom_file}
-echo "351931fe9bb252849b7d37183099047fbe6d7b79dcba013fb6ae19cc1bbd8552 $prom_file" | sha256sum --check
+echo "fca1b17bef8bd19c2ad90caf13d7ffa85e8c4655aa03315fb5e228bd06c4e0ae $prom_file" | sha256sum --check
 tar xzvf ${prom_file}
 sudo cp prometheus-${prom_version}.linux-amd64/promtool /usr/local/bin/
 


### PR DESCRIPTION
fixes lightbend/console-backend#646

If jmx_exporter version of jvm metrics is available for a workload,
we'll use those. If not then we'll try the Cinnamon version.

Some of the Cinnamon metrics have a GC or Pool value embedded in the
name, so here we parse those out into a tag to get the same ergonomics
as jmx_exporter. This keeps the jmx_exporter or cinnamon_metric
expression lined up, compresses multiple promql expressions into one,
and handles any gc or pool type found without having to know them ahead
of time.

Note that for GC Rate and GC Time we are using Prometheus 2.7 subquery
features so promtool and in-cluster prometheus must be >= 2.7 for these
to work.

Here's a Pipelines Akka Streamlet with a mix of jmx_exporter and Cinnamon jvm metrics:

![image](https://user-images.githubusercontent.com/1753336/54716816-e205bf00-4b13-11e9-9a6c-d2d42b7306d4.png)
