### PR TITLE
Pipelines dashboards

### DIFF
--- a/enterprise-suite/console-api/static-rules.yml
+++ b/enterprise-suite/console-api/static-rules.yml
@@ -72,4 +72,4 @@
   expr: sum by (app_kubernetes_io_component, app_kubernetes_io_managed_by, app_kubernetes_io_name, app_kubernetes_io_part_of, es_monitor_type, es_workload, namespace, topic) (kafka_producer_producer_metrics_record_send_rate)
 
 - record: kafka_consumer_topic_lag_max
-  expr: max by (app_kubernetes_io_component, app_kubernetes_io_managed_by, app_kubernetes_io_name, app_kubernetes_io_part_of, es_monitor_type, es_workload, namespace, topic, instance) (kafka_consumer_consumer_fetch_manager_metrics_records_lag_max >= 0)
+  expr: max by (app_kubernetes_io_component, app_kubernetes_io_managed_by, app_kubernetes_io_name, app_kubernetes_io_part_of, es_monitor_type, es_workload, namespace, topic, instance) (clamp_min(kafka_consumer_consumer_fetch_manager_metrics_records_lag_max,0))

--- a/enterprise-suite/es-grafana/akka-stream-exporter.json
+++ b/enterprise-suite/es-grafana/akka-stream-exporter.json
@@ -1,0 +1,50 @@
+[
+    {
+        "graphName": "Stream Throughput",
+        "promQL": [
+            {
+                "expr": "rate(akka_stream_stream_throughput{ContextTags}[1m])",
+                "legendFormat": "{{stream}}"
+            }
+        ],
+        "yaxes": {
+            "format": "ops"
+        }
+    },
+    {
+        "graphName": "Stream Processing Time",
+        "promQL": [
+            {
+                "expr": "akka_stream_stream_flow_time_ns{ContextTags}",
+                "legendFormat": "{{stream}} quantile {{quantile}}"
+            }
+        ],
+        "yaxes": {
+            "format": "ns"
+        }
+    },
+    {
+        "graphName": "Slowest Operators",
+        "promQL": [
+            {
+                "expr": "topk(3, akka_stream_operator_processing_time_ns{ContextTags,quantile=\"0.99\"})",
+                "legendFormat": "{{stream}} {{operator}}"
+            }
+        ],
+        "yaxes": {
+            "format": "ns"
+        }
+    },
+    {
+        "graphName": "Operator Failures",
+        "promQL": [
+            {
+                "expr": "sum by (stream) (rate(akka_stream_operator_operator_failure{ContextTags}[5m]))",
+                "legendFormat": "{{stream}}"
+            }
+        ],
+        "yaxes": {
+            "format": "ops"
+        }
+    }
+]

--- a/enterprise-suite/es-grafana/kafka-consumer-exporter.json
+++ b/enterprise-suite/es-grafana/kafka-consumer-exporter.json
@@ -1,0 +1,23 @@
+[
+    {
+        "graphName": "Consumer Throughput",
+        "promQL": [
+            {
+                "expr": "kafka_consumer_topic_consumed_rate{ContextTags}",
+                "legendFormat": "{{topic}}"
+            }
+        ],
+        "yaxes": {
+            "format": "rps"
+        }
+    },
+    {
+        "graphName": "Consumer Lag",
+        "promQL": [
+            {
+                "expr": "kafka_consumer_topic_lag_max{ContextTags}",
+                "legendFormat": "{{topic}}"
+            }
+        ]
+    }
+]

--- a/enterprise-suite/es-grafana/kafka-producer-exporter.json
+++ b/enterprise-suite/es-grafana/kafka-producer-exporter.json
@@ -1,0 +1,14 @@
+[
+    {
+        "graphName": "Producer Throughput",
+        "promQL": [
+            {
+                "expr": "kafka_producer_topic_send_rate{ContextTags}",
+                "legendFormat": "{{topic}}"
+            }
+        ],
+        "yaxes": {
+            "format": "wps"
+        }
+    }
+]

--- a/enterprise-suite/es-grafana/spark-driver-exporter.json
+++ b/enterprise-suite/es-grafana/spark-driver-exporter.json
@@ -1,0 +1,20 @@
+[
+    {
+        "graphName": "Driver Events",
+        "promQL": [
+            {
+                "expr": "rate(spark_driver_livelistenerbus_numeventsposted_count{ContextTags}[5m])",
+                "legendFormat": "{{es_workload}}"
+            }
+        ]
+    },
+    {
+        "graphName": "Executor Management Queue Size",
+        "promQL": [
+            {
+                "expr": "spark_driver_livelistenerbus_queue_executormanagement_size{ContextTags}",
+                "legendFormat": "{{es_workload}}"
+            }
+        ]
+    }
+]

--- a/enterprise-suite/es-grafana/spark-executor-exporter.json
+++ b/enterprise-suite/es-grafana/spark-executor-exporter.json
@@ -1,0 +1,38 @@
+[
+    {
+        "graphName": "Shuffle Records Read Rate",
+        "promQL": [
+            {
+                "expr": "rate(spark_executor_shufflerecordsread_count{ContextTags}[5m])",
+                "legendFormat": "{{kubernetes_pod_name}}"
+            }
+        ],
+        "yaxes": {
+            "format": "rps"
+        }
+    },
+    {
+        "graphName": "Shuffle Records Write Rate",
+        "promQL": [
+            {
+                "expr": "rate(spark_executor_shufflerecordswritten_count{ContextTags}[5m])",
+                "legendFormat": "{{kubernetes_pod_name}}"
+            }
+        ],
+        "yaxes": {
+            "format": "wps"
+        }
+    },
+    {
+        "graphName": "CPU Utilization",
+        "promQL": [
+            {
+                "expr": "rate(spark_executor_cputime_count{ContextTags}[5m]) / 1000000000",
+                "legendFormat": "{{kubernetes_pod_name}}"
+            }
+        ],
+        "yaxes": {
+            "format": "percentunit"
+        }
+    }
+]

--- a/enterprise-suite/es-grafana/spark-operator-exporter.json
+++ b/enterprise-suite/es-grafana/spark-operator-exporter.json
@@ -1,0 +1,35 @@
+[
+    {
+        "graphName": "Running Executors",
+        "promQL": [
+            {
+                "expr": "spark_app_executor_running_count{ContextTags}",
+                "legendFormat": "{{es_workload}}"
+            }
+        ]
+    },
+    {
+        "graphName": "Executor Failure Rate",
+        "promQL": [
+            {
+                "expr": "rate(spark_app_executor_failure_count{ContextTags}[5m])",
+                "legendFormat": "{{es_workload}}"
+            }
+        ],
+        "yaxes": {
+            "format": "ops"
+        }
+    },
+    {
+        "graphName": "Controller Retry Rate",
+        "promQL": [
+            {
+                "expr": "rate(spark_application_controller_retries{ContextTags}[5m])",
+                "legendFormat": "{{es_workload}}"
+            }
+        ],
+        "yaxes": {
+            "format": "ops"
+        }
+    }
+]


### PR DESCRIPTION
Fixes lightbend/console-backend#630

Provides new service types for akka-stream, kafka-consumer, kafka-producer, spark-operator, spark-driver, spark-executor.

Example of sections for Pipelines Akka Streamlet

https://console-server-lightbend.zandvoort.lightbend.com/service/grafana/dashboard/script/exporter-async.js?namespace=call-record-pipeline&es_workload=call-record-pipeline-cdr-validator&from=now-4h&service-type=kafka-consumer,kafka-producer,akka-stream,jvm,kubernetes&orgId=1

Example of sections for Pipelines Spark Streamlet

https://console-server-lightbend.zandvoort.lightbend.com/service/grafana/dashboard/script/exporter-async.js?namespace=call-record-pipeline&es_workload=call-record-pipeline-cdr-aggregator-exec&from=now-4h&service-type=kafka-consumer,kafka-producer,spark-executor,jvm,kubernetes&orgId=1