### PR TITLE
console-api v1.0.12: fix default monitor loading

### DIFF
--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -10,7 +10,7 @@ consoleUIConfig:
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-console
 esConsoleVersion: v1.0.3
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/console-api
-esMonitorVersion: v1.0.11
+esMonitorVersion: v1.0.12
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-grafana
 esGrafanaVersion: v0.2.2
 # prom/prometheus


### PR DESCRIPTION
Due to blank hash digest change, default monitors can't load at startup
anymore. v1.0.12 fixes this.