### PR TITLE
Run OpenShift lbc.py uninstall with --delete-pvcs

### DIFF
--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -32,7 +32,7 @@ purge-console-openshift: purge-console
 
 .PHONY: purge-console
 purge-console:
-	-TILLER_NAMESPACE=$(NAMESPACE) ../scripts/lbc.py uninstall
+	-TILLER_NAMESPACE=$(NAMESPACE) ../scripts/lbc.py uninstall --delete-pvcs
 
 ginkgo_args := -r -compilers=2 --progress --failFast --randomizeAllSpecs --slowSpecThreshold=30 -- --namespace=$(NAMESPACE) --tiller-namespace=$(NAMESPACE)
 


### PR DESCRIPTION
`purge-console` Makefile target doesn't work correctly, lbc.py needs `--delete-pvcs` to actually uninstall the Console.

From a recent Central Park log:
```
$ make -C enterprise-suite/gotests purge-console-openshift NAMESPACE=console-backend-go-tests || true
make: Entering directory '/home/travis/gopath/src/github.com/lightbend/console-charts/enterprise-suite/gotests'
TILLER_NAMESPACE=console-backend-go-tests ../scripts/lbc.py uninstall
Assuming reclaim policy for PV alertmanager-storage from that of storage class.  Proceed with caution.
Assuming reclaim policy for PV es-grafana-storage from that of storage class.  Proceed with caution.
Assuming reclaim policy for PV prometheus-storage from that of storage class.  Proceed with caution.
WARNING: Given the current and desired configs, continued (un)installation will result in the loss of Console data.
   info: Reclaim policy for PV pvc-c2f34d63-4b50-11e9-8216-0e7f41240914 for claim alertmanager-storage is not 'Retain'
   info: Reclaim policy for PV pvc-c2f4482f-4b50-11e9-8216-0e7f41240914 for claim es-grafana-storage is not 'Retain'
   info: Reclaim policy for PV pvc-c2f53518-4b50-11e9-8216-0e7f41240914 for claim prometheus-storage is not 'Retain'
Invoke again with '--delete-pvcs' to proceed anyway, but save your data first if so desired
Stopping
Makefile:35: recipe for target 'purge-console' failed
make: [purge-console] Error 1 (ignored)
```