### PR TITLE
Fix broken k8s memory usage graph when there are multiple Lightbend Console installed in the cluster

### DIFF
--- a/enterprise-suite/es-grafana/kubernetes-exporter.json
+++ b/enterprise-suite/es-grafana/kubernetes-exporter.json
@@ -15,7 +15,7 @@
         "graphName": "Resident Memory Used Percent",
         "promQL": [
             {
-                "expr": "sum without(container_name,id,image,name)((container_memory_rss{ContextTags} / container_spec_memory_limit_bytes < +Inf or container_memory_rss{ContextTags} / on (node_name) group_left kube_node_status_capacity_memory_bytes) * 100)",
+                "expr": "sum without(container_name,id,image,name)((container_memory_rss{ContextTags} / container_spec_memory_limit_bytes < +Inf or container_memory_rss{ContextTags} / on (node_name) group_left max without (instance, namespace)(kube_node_status_capacity_memory_bytes)) * 100)",
                 "legendFormat": "{{kubernetes_pod_name}}"
             }
         ],
@@ -27,7 +27,7 @@
         "graphName": "Total Memory Used Percent",
         "promQL": [
             {
-                "expr": "sum without(container_name,id,image,name)((container_memory_usage_bytes{ContextTags} / container_spec_memory_limit_bytes < +Inf or container_memory_usage_bytes{ContextTags} / on (node_name) group_left kube_node_status_capacity_memory_bytes) * 100)",
+                "expr": "sum without(container_name,id,image,name)((container_memory_usage_bytes{ContextTags} / container_spec_memory_limit_bytes < +Inf or container_memory_usage_bytes{ContextTags} / on (node_name) group_left max without (instance, namespace)(kube_node_status_capacity_memory_bytes)) * 100)",
                 "legendFormat": "{{kubernetes_pod_name}}"
             }
         ],

--- a/enterprise-suite/es-grafana/kubernetes-exporter.json
+++ b/enterprise-suite/es-grafana/kubernetes-exporter.json
@@ -27,7 +27,7 @@
         "graphName": "Total Memory Used Percent",
         "promQL": [
             {
-                "expr": "sum without(container_name,id,image,name)((container_memory_usage_bytes{ContextTags} / container_spec_memory_limit_bytes < +Inf or container_memory_usage_bytes{ContextTags} / on (node_name) group_left max without (instance, namespace)(kube_node_status_capacity_memory_bytes)) * 100)",
+                "expr": "sum without(container_name,id,image,name)((container_memory_working_set_bytes{ContextTags} / container_spec_memory_limit_bytes < +Inf or container_memory_usage_bytes{ContextTags} / on (node_name) group_left max without (instance, namespace)(kube_node_status_capacity_memory_bytes)) * 100)",
                 "legendFormat": "{{kubernetes_pod_name}}"
             }
         ],


### PR DESCRIPTION
Problem:  If we go to workload page and click "grafana" icon, we cannot see graphs "Resident Memory Used Percent" and "Total Memory Used Percent"  in grafana if there are multiple Lightbend Console installed in cluster in different namespace 

![Screen Shot 2019-03-27 at 3 10 09 PM](https://user-images.githubusercontent.com/11674700/55115899-df224580-50a2-11e9-9894-6dc6a649cf65.png)


Solution: 
 I understand that user "should" use prometheusDomain to scrap data if they install multiple Lightbend Console. However, just in case different users both use the "default" prometheusDomain for their Lightbend Console(It sounds like a common case....).

I write a "defensive" dedupe promQL query, use `max without (instance, namespace)` to remove the duplicated information created by multiple kube-state-metrics
