### PR TITLE
Don't force reinstall automatically

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -605,14 +605,16 @@ def install(creds_file):
 
         # Check status of existing install under the same release name
         status, namespace = install_status(args.helm_name)
-        if status == 'deployed':
+        if status == 'deployed' or status == 'failed':
+            if status == 'failed':
+                printerr('info: found a failed installation under name {}, will attempt to upgrade'.format(args.helm_name))
+                printerr('info: if this fails, pass `--force-install` to delete the prior installation first')
+
             if args.force_install:
                 uninstall(status=status, namespace=namespace)
             else:
                 should_upgrade = True
-        elif status == 'failed':
-            printerr('info: found a failed installation under name {}, it will be deleted'.format(args.helm_name))
-            uninstall(status=status, namespace=namespace)
+
         elif status == 'notfound':
             # Continue with the install when status is 'notfound'
             pass

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -164,18 +164,7 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=0,
                    stdout='LAST DEPLOYED: Tue Nov 13 09:59:46 2018\nNAMESPACE: lightbend\nSTATUS: FAILED\nNOTES: blah')
-        expect_cmd(r'helm delete --purge enterprise-suite')
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend\s+--values \S+')
-        lbc.main(['install', '--skip-checks', '--delete-pvcs', '--creds='+self.creds_file])
-
-    def test_install_helm_failed_reuse(self):
-        # Failed previous install, PVCs found for reuse
-        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
-        expect_cmd(r'helm repo update')
-        expect_cmd(r'helm status enterprise-suite', returncode=0,
-                   stdout='LAST DEPLOYED: Tue Nov 13 09:59:46 2018\nNAMESPACE: lightbend\nSTATUS: FAILED\nNOTES: blah')
-        expect_cmd(r'helm delete --purge enterprise-suite')
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend\s+--values \S+')
+        expect_cmd(r'helm upgrade enterprise-suite es-repo/enterprise-suite\s+--values \S+')
         lbc.main(['install', '--skip-checks', '--delete-pvcs', '--creds='+self.creds_file])
 
     def test_install_not_finished(self):

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -315,8 +315,9 @@ if __name__ == '__main__':
     lbc.run = test_run
     lbc.fail = test_fail
     lbc.printerr = test_print
-    lbc.printinfo = test_print
+    lbc.printout = test_print
     lbc.make_tempdir = test_make_tempdir
+    lbc.REINSTALL_WAIT_SECS = 0
 
     # Run tests
     unittest.main()


### PR DESCRIPTION
This is bad behaviour - many times it is possible to perform an upgrade due
to a failed install (such as when the wrong values were set on the 
upgrade). Force install should only happen if the user requests it.

Also wait a short while when force reinstalling, to avoid the bug where the
uninstall does not happen fast enough. It's not perfect - but simplest thing
we can do (arguably this should be added to Helm).

For https://github.com/lightbend/console-backend/issues/645