### PR TITLE
Add gotests for upgrade failure on PVC loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build
 node_modules
 whitesource*
+__pycache__

--- a/enterprise-suite/gotests/args/args.go
+++ b/enterprise-suite/gotests/args/args.go
@@ -1,4 +1,4 @@
-package testenv
+package args
 
 import (
 	"flag"

--- a/enterprise-suite/gotests/tests/apiserverproxy/apiserverproxy_test.go
+++ b/enterprise-suite/gotests/tests/apiserverproxy/apiserverproxy_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/urls"
@@ -34,7 +35,7 @@ var _ = AfterSuite(func() {
 var _ = Describe("all:apiserverproxy", func() {
 	DescribeTable("can access via apiserver proxy", func(serviceName, servicePath string) {
 		url := fmt.Sprintf("http://127.0.0.1:%d/api/v1/namespaces/%s/services/%s:http/proxy%s",
-			proxyPort, testenv.ConsoleNamespace, serviceName, servicePath)
+			proxyPort, args.ConsoleNamespace, serviceName, servicePath)
 		By(url)
 		_, err := urls.Get200(url)
 		Expect(err).ToNot(HaveOccurred())

--- a/enterprise-suite/gotests/tests/console/console_test.go
+++ b/enterprise-suite/gotests/tests/console/console_test.go
@@ -3,6 +3,7 @@ package console
 import (
 	"testing"
 
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/monitor"
 
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
@@ -51,7 +52,7 @@ var _ = Describe("all:verify", func() {
 
 	Context("Console", func() {
 		It("is verified to be installed correctly", func() {
-			Expect(lbc.Verify(testenv.ConsoleNamespace, testenv.TillerNamespace)).Should(Succeed())
+			Expect(lbc.Verify(args.ConsoleNamespace, args.TillerNamespace)).Should(Succeed())
 		})
 
 		It("can access the legacy es-monitor-api endpoint still", func() {

--- a/enterprise-suite/gotests/tests/grafana/grafana_test.go
+++ b/enterprise-suite/gotests/tests/grafana/grafana_test.go
@@ -3,6 +3,7 @@ package console
 import (
 	"testing"
 
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/kube"
 
@@ -28,7 +29,7 @@ var _ = Describe("all:grafana", func() {
 		// Exact message is:
 		// t=2019-03-26T12:48:10+0000 lvl=eror msg="Failed to auto update app dashboard" logger=plugins pluginId=cinnamon-prometheus-app error="Dashboard not found"
 		// We test for "lvl=eror" in case Grafana changes this error message.
-		Expect(kube.GetLogs(testenv.ConsoleNamespace, "app.kubernetes.io/component=grafana")).
+		Expect(kube.GetLogs(args.ConsoleNamespace, "app.kubernetes.io/component=grafana")).
 			ToNot(ContainSubstring("lvl=eror"))
 	})
 })

--- a/enterprise-suite/gotests/tests/ingress/ingress_test.go
+++ b/enterprise-suite/gotests/tests/ingress/ingress_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
 
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
@@ -39,11 +40,11 @@ var _ = Describe("minikube:ingress", func() {
 		extAPI := testenv.K8sClient.ExtensionsV1beta1()
 
 		// On repeated test runs the ingress might already exist, so check before creating a new one
-		_, err := extAPI.Ingresses(testenv.ConsoleNamespace).Get(testIngressName, metav1.GetOptions{})
+		_, err := extAPI.Ingresses(args.ConsoleNamespace).Get(testIngressName, metav1.GetOptions{})
 		if err != nil {
 
 			// Figure out which port expose-es-console service uses
-			consoleService, err := coreAPI.Services(testenv.ConsoleNamespace).Get(consoleServiceName, metav1.GetOptions{})
+			consoleService, err := coreAPI.Services(args.ConsoleNamespace).Get(consoleServiceName, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 			servicePort := consoleService.Spec.Ports[0].Port
 
@@ -76,7 +77,7 @@ var _ = Describe("minikube:ingress", func() {
 					},
 				},
 			}
-			_, err = extAPI.Ingresses(testenv.ConsoleNamespace).Create(ingress)
+			_, err = extAPI.Ingresses(args.ConsoleNamespace).Create(ingress)
 			Expect(err).To(Succeed())
 		}
 

--- a/enterprise-suite/gotests/tests/installer/installer_test.go
+++ b/enterprise-suite/gotests/tests/installer/installer_test.go
@@ -1,0 +1,75 @@
+package installer
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/lbc"
+
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestInstaller(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Installer (lbc.py) Suite")
+}
+
+var _ = BeforeSuite(func() {
+	testenv.InitEnv()
+})
+
+var _ = AfterSuite(func() {
+	testenv.CloseEnv()
+})
+
+func write(file *os.File, content string) {
+	if _, err := file.Write([]byte(content)); err != nil {
+		panic(err)
+	}
+}
+
+var _ = Describe("all:lbc.py", func() {
+	var (
+		valuesFile *os.File
+	)
+
+	BeforeEach(func() {
+		var err error
+		valuesFile, err = ioutil.TempFile("", "values-*.yaml")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := os.Remove(valuesFile.Name())
+		Expect(err).To(Succeed())
+	})
+
+	Context("upgrades", func() {
+		Context("disable persistent volumes", func() {
+			// Assumption is testenv.InitEnv() sets usePersistentVolumes=true
+
+			BeforeEach(func() {
+				write(valuesFile, `usePersistentVolumes: false`)
+			})
+
+			It("should fail if we don't provide --delete-pvcs", func() {
+				Expect(lbc.Install([]string{}, []string{"-f " + valuesFile.Name()})).ToNot(Succeed())
+			})
+
+			It("should succeed if we provide --delete-pvcs", func() {
+				Expect(lbc.Install([]string{}, []string{"-f " + valuesFile.Name()})).To(Succeed())
+			})
+		})
+	})
+
+	Context("arg parsing", func() {
+		It("should fail if conflicting namespaces", func() {
+			Expect(lbc.Install([]string{"--namespace=" + args.ConsoleNamespace},
+				[]string{"--namespace=my-busted-namespace"})).ToNot(Succeed())
+		})
+	})
+})

--- a/enterprise-suite/gotests/tests/installer/installer_test.go
+++ b/enterprise-suite/gotests/tests/installer/installer_test.go
@@ -61,7 +61,7 @@ var _ = Describe("all:lbc.py", func() {
 			})
 
 			It("should succeed if we provide --delete-pvcs", func() {
-				Expect(lbc.Install([]string{}, []string{"-f " + valuesFile.Name()})).To(Succeed())
+				Expect(lbc.Install([]string{"--delete-pvcs"}, []string{"-f " + valuesFile.Name()})).To(Succeed())
 			})
 		})
 	})

--- a/enterprise-suite/gotests/tests/installer/installer_test.go
+++ b/enterprise-suite/gotests/tests/installer/installer_test.go
@@ -50,9 +50,8 @@ var _ = Describe("all:lbc.py", func() {
 
 	Context("upgrades", func() {
 		Context("disable persistent volumes", func() {
-			// Assumption is testenv.InitEnv() sets usePersistentVolumes=true
-
 			BeforeEach(func() {
+				Expect(lbc.Install([]string{}, []string{"--set usePersistentVolumes=true"})).To(Succeed(), "install with PVs")
 				write(valuesFile, `usePersistentVolumes: false`)
 			})
 

--- a/enterprise-suite/gotests/tests/portforward/portforward_test.go
+++ b/enterprise-suite/gotests/tests/portforward/portforward_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
 
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
@@ -27,7 +28,7 @@ var _ = BeforeSuite(func() {
 
 	localPort = util.FindFreePort()
 	portForwardCmd = util.Cmd("kubectl", "port-forward",
-		"-n", testenv.ConsoleNamespace,
+		"-n", args.ConsoleNamespace,
 		consoleDeployment,
 		fmt.Sprintf("%d:%d", localPort, consoleRemotePort))
 	Expect(portForwardCmd.StartAsync()).To(Succeed())

--- a/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
+++ b/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/kube"
@@ -38,13 +39,13 @@ var _ = BeforeSuite(func() {
 
 	// Create test app deployments + services
 	for res, depName := range appYamls {
-		err = kube.ApplyYaml(testenv.ConsoleNamespace, res)
+		err = kube.ApplyYaml(args.ConsoleNamespace, res)
 		Expect(err).To(Succeed())
 
 		// wait for deployment to become ready
 		if len(depName) > 0 {
 			err = util.WaitUntilSuccess(util.LongWait, func() error {
-				return kube.IsDeploymentAvailable(testenv.K8sClient, testenv.ConsoleNamespace, depName)
+				return kube.IsDeploymentAvailable(testenv.K8sClient, args.ConsoleNamespace, depName)
 			})
 			Expect(err).To(Succeed())
 		}
@@ -72,7 +73,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	// Delete test app deployments + services
 	for res := range appYamls {
-		if err := kube.DeleteYaml(testenv.ConsoleNamespace, res); err != nil {
+		if err := kube.DeleteYaml(args.ConsoleNamespace, res); err != nil {
 			util.LogG("Unable to remove %v\n", res)
 		}
 	}
@@ -164,7 +165,7 @@ var _ = Describe("all:prometheus", func() {
 
 	Context("k8s service discovery", func() {
 		It("can discover a pod", func() {
-			appInstancesQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test\", namespace=\"%v\"}) ) == 2", testenv.ConsoleNamespace)
+			appInstancesQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test\", namespace=\"%v\"}) ) == 2", args.ConsoleNamespace)
 			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasData(appInstancesQuery)
 			})
@@ -187,7 +188,7 @@ var _ = Describe("all:prometheus", func() {
 		})
 
 		It("can discover a pod with multiple ports", func() {
-			appInstancesWithMultiplePortsQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test-with-multiple-ports\", namespace=\"%v\"}) ) == 4", testenv.ConsoleNamespace)
+			appInstancesWithMultiplePortsQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test-with-multiple-ports\", namespace=\"%v\"}) ) == 4", args.ConsoleNamespace)
 			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasData(appInstancesWithMultiplePortsQuery)
 			})
@@ -195,7 +196,7 @@ var _ = Describe("all:prometheus", func() {
 		})
 
 		It("can discover k8s `Service` resources", func() {
-			appInstancesViaServiceQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test-via-service\", namespace=\"%v\"}) ) == 2", testenv.ConsoleNamespace)
+			appInstancesViaServiceQuery := fmt.Sprintf("count( count by (instance) (ohai{es_workload=\"es-test-via-service\", namespace=\"%v\"}) ) == 2", args.ConsoleNamespace)
 			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				if err := prom.HasData(appInstancesViaServiceQuery); err != nil {
 					return fmt.Errorf("unable to discover app via 'Service' service discovery: %v", err)
@@ -225,7 +226,7 @@ var _ = Describe("all:prometheus", func() {
 			err := util.WaitUntilSuccess(util.LongWait, func() error {
 				return prom.HasData(fmt.Sprintf("count( count by (instance) (up{ "+
 					"job=\"kubernetes-services\", kubernetes_name=\"es-test-service-with-only-endpoints\", namespace=\"%v\""+
-					"}) ) == 1", testenv.ConsoleNamespace))
+					"}) ) == 1", args.ConsoleNamespace))
 			})
 			Expect(err).To(Succeed())
 		})

--- a/enterprise-suite/gotests/util/helm/helm.go
+++ b/enterprise-suite/gotests/util/helm/helm.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
+
 	apiv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/kube"
 )
@@ -20,8 +21,8 @@ const ServiceAccountName = "tiller"
 
 func IsInstalled() bool {
 	cmd := util.Cmd("helm", "version")
-	if testenv.TillerNamespace != "" {
-		cmd = cmd.Env("TILLER_NAMESPACE", testenv.TillerNamespace)
+	if args.TillerNamespace != "" {
+		cmd = cmd.Env("TILLER_NAMESPACE", args.TillerNamespace)
 	}
 	if err := cmd.Run(); err != nil {
 		return false
@@ -34,8 +35,8 @@ func IsInstalled() bool {
 func ReleaseExists(name string) bool {
 	var output strings.Builder
 	cmd := util.Cmd("helm", "list", "--all", "--short", name).CaptureStdout(&output)
-	if testenv.TillerNamespace != "" {
-		cmd = cmd.Env("TILLER_NAMESPACE", testenv.TillerNamespace)
+	if args.TillerNamespace != "" {
+		cmd = cmd.Env("TILLER_NAMESPACE", args.TillerNamespace)
 	}
 
 	if err := cmd.Run(); err != nil {

--- a/enterprise-suite/gotests/util/lbc/lbc.go
+++ b/enterprise-suite/gotests/util/lbc/lbc.go
@@ -4,27 +4,28 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
+
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
 )
 
 const localChartPath = "../../../."
 const lbcPath = "../../../scripts/lbc.py"
 
-func Install(namespace, tillerNamespace string, lbcArgs, helmArgs []string) error {
+func Install(lbcArgs, helmArgs []string) error {
 	cmdArgs := []string{lbcPath, "install", "--local-chart", localChartPath,
-		"--namespace", namespace,
-		"--set prometheusDomain=console-backend-e2e.io",
-		"--delete-pvcs"}
+		"--namespace", args.ConsoleNamespace,
+		"--set prometheusDomain=console-backend-e2e.io"}
 	cmdArgs = append(cmdArgs, lbcArgs...)
 	cmdArgs = append(cmdArgs, "--", "--wait", "--timeout", "110")
 	cmdArgs = append(cmdArgs, helmArgs...)
 	cmd := util.Cmd("/bin/bash", "-c", strings.Join(cmdArgs, " "))
-	if tillerNamespace != "" {
-		cmd = cmd.Env("TILLER_NAMESPACE", tillerNamespace)
+	if args.TillerNamespace != "" {
+		cmd = cmd.Env("TILLER_NAMESPACE", args.TillerNamespace)
 	}
 
 	if err := cmd.Timeout(time.Minute * 2).Run(); err != nil {
-		logDebugInfo(namespace)
+		logDebugInfo(args.ConsoleNamespace)
 		return err
 	}
 

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -377,11 +377,13 @@ def check_pv_usage(uninstalling=False):
         if uninstalling:
             printerr("error: Existing deployment has usePersistentVolumes=true. Uninstall may "
                      "result in the loss of Console data as associated PVCs will be removed.")
-
-        if not wants_pvcs:
+        elif not wants_pvcs:
             printerr("error: Existing deployment has usePersistentVolumes=true, but upgrade has specified "
                      "usePersistentVolumes=false. Upgrade may result in the loss of Console data as associated "
                      "PVCs will be removed.")
+        else:
+            # Nothing potentially dangerous here - we are neither uninstalling nor setting usePersistentVolumes=false.
+            return
 
         printerr("error: Invoke with '--delete-pvcs' to proceed")
         fail("error: Stopping")

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -352,146 +352,45 @@ def check_resource_list(cmd, expected, fail_msg):
     return False
 
 
-# Returns two lists.  For each of the PVC types we care about, the associated PV
-# is in the first or second list if the reclaim policy is RETAIN or not respectively.
-# Each list element is a tuple of PV name, claim, and status.
-def pvs_retained_and_not(namespace):
-    claimNames = '"' + '" "'.join(CONSOLE_PVCS) + '"'
-    go_template = ('{{ range .items }}{{ if eq .spec.claimRef.name ' + claimNames + ' }}'
-                   '{{ printf "%s %s %s %s\\n" .metadata.name .spec.persistentVolumeReclaimPolicy '
-                   '.spec.claimRef.name .status.phase }}{{ end }}{{ end }}')
-    returncode, stdout, _ = run("kubectl get pv -o go-template='{}'"
-                                .format(go_template), show_stderr=False)
-    # stdout contains...
-    # pvc-8149517b-3bae-11e9-83b7-08002755d2dd Delete alertmanager-storage Bound
-
-    pvs = []
-    retained = []
-    notRetained = []
-
-    if returncode != 0:
-        ## try alternate method here
-        # Get PV info via PVCs
-        go_template = ('{{ range .items }}{{ if eq .metadata.name ' + claimNames + ' }}'
-                       '{{ printf "%s %s %s %s\\n" .metadata.name .spec.volumeName .spec.storageClassName '
-                       '.status.phase }}{{ end }}{{ end }}')
-        returncode, stdout, _ = run("kubectl get pvc -n {} -o go-template='{}'"
-                                    .format(namespace, go_template))
-        # stdout contains...
-        # prometheus-storage pvc-81508cb1-3bae-11e9-83b7-08002755d2dd standard Bound
-        if returncode == 0:
-            # Now get default reclaim policy for storage class
-            for pv in stdout.splitlines():
-                words = pv.split()
-
-                go_template = '{{ printf "%s %s\\n" .metadata.name .reclaimPolicy }}'
-                returncode, stdout, _ = run("kubectl get storageclass {} -o go-template='{}'"
-                                            .format(words[2], go_template))
-                # stdout contains...
-                # standard Delete
-
-                if returncode == 0:
-                    storage = stdout.split()
-                    # This matches output we would get direct from "get pv" above
-                    pvs.append('{} {} {} {}'
-                               .format(words[1], storage[1], words[0], words[3]))
-                    printerr("Assuming reclaim policy for PV {} from that of storage class.  Proceed with caution."
-                             .format(words[0]))
-                else:
-                    printerr("Unable to retrieve Persistent Volume info.  Proceed with caution.")
-        else:
-            printerr("Unable to retrieve Persistent Volume info.  Proceed with caution.")
-    else:
-        pvs = stdout.splitlines()
-
-    for pv in pvs:
-        words = pv.split()
-
-        if words[1] == 'Retain':
-            list = retained
-        else:
-            list = notRetained
-        list.append((words[0], words[2], words[3]))
-
-    return (retained, notRetained)
-
-
 # Check that the use of persistentVolumes before and after the (un)install will not lead to data loss.
-def check_pv_usage(aboutToUninstall=False, namespace=None):
+def check_pv_usage(uninstalling=False):
     # Retrieve the current helm installation computed values.
     returncode, helm_get_stdout, helm_get_stderr = run('helm get ' + args.helm_name,
                                                        DEFAULT_TIMEOUT, show_stderr=False)
-
-    if namespace is None:
-        namespace = args.namespace
 
     if 'usePersistentVolumes' not in values:
         printerr("warn: can't determine the value of usePersistentVolumes, unable to parse helm values")
         return
 
-    wantsPVs = values['usePersistentVolumes'] is True
+    wants_pvcs = values['usePersistentVolumes'] is True
 
     if 'Error: release: "{}" not found'.format(args.helm_name) in helm_get_stderr:
-        # Fresh install so we're good with whatever but...
-        retainedPVs, _ = pvs_retained_and_not(namespace)
-        if len(retainedPVs) > 0:
-            # Look for orphaned PVs that are associated with Console.
-            # Even with usePersistentVolumes=true they'll be orphaned if they don't have status of "Available"
-            # (User was warned about this at uninstall time but reminding them...)
-            allAvailable = len([True for i in retainedPVs if i[2] != 'Available']) == 0
-            if ((not wantsPVs) or (wantsPVs and not allAvailable)):
-                printerr("WARNING: Console data exists in orphaned Persistent Volumes.")
-                if (not wantsPVs):
-                    printerr("         Set --usePersistentVolumes=true to reuse data.")
-                elif (wantsPVs and not allAvailable):
-                    printerr("         Manual intervention will be required to reuse it with the Console, "
-                             "or to actually delete it.")
-                printerr("         Proceeding with installation using new datasets.")
-                printerr("         See associated documentation at "
-                         "https://developer.lightbend.com/docs/console/current/installation/storage.html.")
-                for pv in retainedPVs:
-                    printerr(
-                        "   info: Reclaim policy for PV {} for claim {} is 'Retain' with status {}".format(pv[0], pv[1],
-                                                                                                           pv[2]))
         return
-    elif returncode != 0:
+
+    if returncode != 0:
         printerr("Unable to retrieve release information.  Proceed with caution.")
         return
 
-    hasPVs = 'usePersistentVolumes: true' in helm_get_stdout
+    has_pvcs = 'usePersistentVolumes: true' in helm_get_stdout
 
-    if ((hasPVs and not wantsPVs) or (hasPVs and aboutToUninstall)):
-        # Chance of losing real data here.
-        # If    we're changing from usePersistentVolumes=true to usePersistentVolumes=false
-        #       (which means going from PV to emptyDir volume)
-        #    or
-        #       we're about to "helm delete" and usePersistentVolumes was true
+    if has_pvcs:
+        if uninstalling:
+            printerr("error: Existing deployment has usePersistentVolumes=true. Uninstall may "
+                     "result in the loss of Console data as associated PVCs will be removed.")
 
-        retainedPVs, notRetainedPVs = pvs_retained_and_not(namespace)
+        if not wants_pvcs:
+            printerr("error: Existing deployment has usePersistentVolumes=true, but upgrade has specified "
+                     "usePersistentVolumes=false. Upgrade may result in the loss of Console data as associated "
+                     "PVCs will be removed.")
 
-        if len(notRetainedPVs) > 0:
-            printerr("WARNING: Given the current and desired configs, continued (un)installation will "
-                     "result in the loss of Console data.")
-            for pv in notRetainedPVs:
-                printerr("   info: Reclaim policy for PV {} for claim {} is not 'Retain'".format(pv[0], pv[1]))
-            printerr("Invoke again with '--delete-pvcs' to proceed anyway")
-            fail("Stopping")
-
-        if len(retainedPVs) > 0:
-            printerr("WARNING: Given the current and desired configs, this (un)installation will "
-                     "orphan existing Console data.")
-            printerr("         Manual intervention will be required to reuse it with the Console, or to actually "
-                     "delete it.")
-            printerr("         See associated documentation at "
-                     "https://developer.lightbend.com/docs/console/current/installation/storage.html.")
-            for pv in retainedPVs:
-                printerr("   info: Reclaim policy for PV {} for claim {} is 'Retain'".format(pv[0], pv[1]))
+        printerr("error: Invoke with '--delete-pvcs' to proceed")
+        fail("error: Stopping")
 
 
 # Takes helm style "key1=value1,key2=value2" string and returns a list of (key, value)
 # pairs. Supports quoting, escaped or non-escaped commas and values with commas inside, eg.:
-#  parse_set_string('am=amg01:9093,amg02:9093') -> [('am', 'amg01:9093,amg02:9093')]
-#  parse_set_string('am="am01,am02",es=NodePort') -> [('am', 'am01,am02'), ('es', 'NodePort')]
+#   parse_set_string('am=amg01:9093,amg02:9093') -> [('am', 'amg01:9093,amg02:9093')]
+#   parse_set_string('am="am01,am02",es=NodePort') -> [('am', 'am01,am02'), ('es', 'NodePort')]
 def parse_set_string(s):
     # Keyval pair with commas allowed
     keyval_pair_re = re.compile(r'(\w+)=([\w\-\+\*\:\.\\,]+)')
@@ -666,7 +565,7 @@ def uninstall(status=None, namespace=None):
         fail('Unable to delete console installation {} - it is already being deleted'.format(args.helm_name))
     else:
         if not args.delete_pvcs:
-            check_pv_usage(aboutToUninstall=True, namespace=namespace)
+            check_pv_usage(uninstalling=True)
 
         printerr("info: Deleting previous console installation {} with status '{}'".format(args.helm_name, status))
         execute('helm delete --purge ' + args.helm_name)


### PR DESCRIPTION
Also simplify PVC check:
- Remove retained PV checking. We only check the helm flags now, this is
substantially faster and simpler (the PV checking could take 10s+).
- Improve error messages.

Also test conflicting namespace logic.

There is a lot more we could test here, but I think this is a good start
for one PR.

part of https://github.com/lightbend/console-backend/issues/608