### PR TITLE
add additonal selector for monitor without using the 'title' attribute

### DIFF
--- a/enterprise-suite/tests/e2e/cypress/integration/grafana.spec.ts
+++ b/enterprise-suite/tests/e2e/cypress/integration/grafana.spec.ts
@@ -11,7 +11,7 @@ describe('Grafana Test', () => {
   it('open grafana url in monitor page', () => {
     // make sure monitor is ready
     Navigation.goWorkloadPageByClick('es-demo');
-    Navigation.clickMonitor('akka_processing_time');
+    Navigation.clickMonitorByName('akka_processing_time');
 
     // start test
     cy.visit('/namespaces/lightbend/workloads/es-demo/monitors/akka_processing_time', {

--- a/enterprise-suite/tests/e2e/cypress/integration/monitor-history.spec.ts
+++ b/enterprise-suite/tests/e2e/cypress/integration/monitor-history.spec.ts
@@ -41,7 +41,7 @@ describe('History Log Test', () => {
     // go to monitor page and check history
     Util.validateUrlPath('/namespaces/lightbend/workloads/console-frontend');
     Util.validateMonitorCountGte(3);
-    Navigation.clickMonitor(monitorName);
+    Navigation.clickMonitorByName(monitorName);
     Util.validateUrlPath(`/namespaces/lightbend/workloads/console-frontend/monitors/${monitorName}`);
 
     History.validateCreatedIsIndex(1);

--- a/enterprise-suite/tests/e2e/cypress/integration/monitor-history.spec.ts
+++ b/enterprise-suite/tests/e2e/cypress/integration/monitor-history.spec.ts
@@ -41,7 +41,7 @@ describe('History Log Test', () => {
     // go to monitor page and check history
     Util.validateUrlPath('/namespaces/lightbend/workloads/console-frontend');
     Util.validateMonitorCountGte(3);
-    Navigation.clickMonitorByName(monitorName);
+    Navigation.clickMonitorByName(monitorName); // this looks for id="name" etc.
     Util.validateUrlPath(`/namespaces/lightbend/workloads/console-frontend/monitors/${monitorName}`);
 
     History.validateCreatedIsIndex(1);

--- a/enterprise-suite/tests/e2e/cypress/integration/monitor-history.spec.ts
+++ b/enterprise-suite/tests/e2e/cypress/integration/monitor-history.spec.ts
@@ -23,7 +23,7 @@ describe('History Log Test', () => {
     // go to monitor page
     Util.validateUrlPath('/namespaces/lightbend/workloads/console-frontend');
     Util.validateMonitorCountGte(3);
-    Navigation.clickMonitor(monitorName);
+    Navigation.clickMonitorByName(monitorName);
     Util.validateUrlPath(`/namespaces/lightbend/workloads/console-frontend/monitors/${monitorName}`);
 
     // check history log: should be 1 item

--- a/enterprise-suite/tests/e2e/cypress/support/navigation.ts
+++ b/enterprise-suite/tests/e2e/cypress/support/navigation.ts
@@ -19,7 +19,7 @@ export class Navigation {
     }
 
     static clickMonitorByName(monId: string) {
-        cy.get(`.monitor-list .monitor-name[monitorname="${monId}"]`, {timeout: 12000}).click();
+        cy.get(`.monitor-list .monitor-name[id="${monId}"]`, {timeout: 12000}).click();
     }
 
     static goMonitorPage(namespace: string, workloadId: string, monitorId: string) {

--- a/enterprise-suite/tests/e2e/cypress/support/navigation.ts
+++ b/enterprise-suite/tests/e2e/cypress/support/navigation.ts
@@ -18,6 +18,10 @@ export class Navigation {
         cy.get(`.monitor-list .monitor-name[title="${monId}"]`, {timeout: 12000}).click();
     }
 
+    static clickMonitorByName(monId: string) {
+        cy.get(`.monitor-list .monitor-name[monitorname="${monId}"]`, {timeout: 12000}).click();
+    }
+
     static goMonitorPage(namespace: string, workloadId: string, monitorId: string) {
         cy.visit(`/namespaces/${namespace}/workloads/${workloadId}/monitors/${monitorId}`);
     }

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -8,7 +8,7 @@ consoleUIConfig:
 # Update these versions for a release.
 #
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-console
-esConsoleVersion: latest
+esConsoleVersion: v1.0.8
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/console-api
 esMonitorVersion: v1.1.3
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-grafana

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -8,7 +8,7 @@ consoleUIConfig:
 # Update these versions for a release.
 #
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-console
-esConsoleVersion: v1.0.7
+esConsoleVersion: latest
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/console-api
 esMonitorVersion: v1.1.1
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-grafana


### PR DESCRIPTION
The title attribute  is now populated with monitor description tooltip - so we need an additional selector for <div class=".monitor-name"> to select upon. Added 'monitorname' as the new attribute.

And a new function to use for monitor click  "clickMonitorByName()"