### PR TITLE
Only scrape the local kube-state-metrics

### DIFF
--- a/enterprise-suite/console-api/prometheus.yml
+++ b/enterprise-suite/console-api/prometheus.yml
@@ -139,13 +139,25 @@ scrape_configs:
     honor_labels: true
 
     relabel_configs:
+      # Only scrape kube-state-metrics.
       - source_labels: [__meta_kubernetes_endpoints_name]
         regex: prometheus-kube-state-metrics
         action: keep
+
+      # Only scrape the kube-state-metrics in the local Console namespace.
+      - source_labels: [__meta_kubernetes_namespace]
+        regex: {{ .Namespace }}
+        action: keep
+
+      # Preserve labels on service.
       - action: labelmap
         regex: __meta_kubernetes_service_label_(.+)
+
+      # Map kube-state-metrics namespace to kubernetes_namespace label.
       - source_labels: [__meta_kubernetes_namespace]
-        target_label: namespace
+        target_label: kubernetes_namespace
+
+      # Map service name to kubernetes_name label.
       - source_labels: [__meta_kubernetes_service_name]
         action: replace
         target_label: kubernetes_name

--- a/enterprise-suite/console-api/prometheus.yml
+++ b/enterprise-suite/console-api/prometheus.yml
@@ -153,10 +153,6 @@ scrape_configs:
       - action: labelmap
         regex: __meta_kubernetes_service_label_(.+)
 
-      # Map kube-state-metrics namespace to kubernetes_namespace label.
-      - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
-
       # Map service name to kubernetes_name label.
       - source_labels: [__meta_kubernetes_service_name]
         action: replace

--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -35,7 +35,7 @@ purge-console-openshift: purge-console
 purge-console:
 	-TILLER_NAMESPACE=$(TILLER_NAMESPACE) ../scripts/lbc.py uninstall --delete-pvcs
 
-ginkgo_args := -r -compilers=2 --progress --failFast --randomizeAllSpecs --slowSpecThreshold=30 -- --namespace=$(NAMESPACE) --tiller-namespace=$(TILLER_NAMESPACE)
+ginkgo_args := -v -r -compilers=2 --progress --failFast --randomizeAllSpecs --slowSpecThreshold=30 -- --namespace=$(NAMESPACE) --tiller-namespace=$(TILLER_NAMESPACE)
 
 .PHONY: run-tests-minikube
 run-tests-minikube:

--- a/enterprise-suite/gotests/tests/alertmanager/alertmanager_test.go
+++ b/enterprise-suite/gotests/tests/alertmanager/alertmanager_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/lbc"
 
-	"k8s.io/client-go/kubernetes/typed/apps/v1"
+	gov1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
@@ -37,7 +37,7 @@ var (
 	console *monitor.Connection
 	alertm  *alertmanager.Connection
 
-	depsClient      v1.DeploymentInterface
+	depsClient      gov1.DeploymentInterface
 	oldConfigmap    *apiv1.ConfigMapVolumeSource
 	alertmanagerDep *appsv1.Deployment
 

--- a/enterprise-suite/gotests/tests/ingress/ingress_test.go
+++ b/enterprise-suite/gotests/tests/ingress/ingress_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	extv1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,7 +85,9 @@ var _ = Describe("minikube:ingress", func() {
 		ip, err := minikube.Ip()
 		Expect(err).To(Succeed())
 
-		httpClient := &http.Client{}
+		httpClient := &http.Client{
+			Timeout: 10*time.Second,
+		}
 		req, err := http.NewRequest("GET", fmt.Sprintf("http://%v/es-console", ip), nil)
 		Expect(err).To(Succeed())
 

--- a/enterprise-suite/gotests/util/monitor/monitor.go
+++ b/enterprise-suite/gotests/util/monitor/monitor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/onsi/ginkgo"
 )
@@ -99,7 +100,9 @@ func (m *Connection) CheckHealth() error {
 }
 
 func makeRequest(req *http.Request) error {
-	httpClient := &http.Client{}
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err

--- a/enterprise-suite/gotests/util/prometheus/prometheus.go
+++ b/enterprise-suite/gotests/util/prometheus/prometheus.go
@@ -34,7 +34,7 @@ type Connection struct {
 func (p *Connection) Query(query string) (*PromResponse, error) {
 	addr := fmt.Sprintf("%v/api/v1/query?query=%v", p.url, url.QueryEscape(query))
 	// Some of the tests with openshift clusters timed out in 20 seconds, so adding a timeout for 45 seconds.
-	timeout := time.Duration(45 * time.Second)
+	timeout := time.Duration(10 * time.Second)
 	client := http.Client{
 		Timeout: timeout,
 	}

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -51,7 +51,7 @@ CONSOLE_PVCS = [
     'prometheus-storage'
 ]
 
-DEFAULT_TIMEOUT = 3
+DEFAULT_TIMEOUT = 10
 REINSTALL_WAIT_SECS = 5
 
 # Parsed commandline args
@@ -185,7 +185,7 @@ def check_kubectl(minishift=False):
     # Check if kubectl is connected to a cluster. If not connected, version query will timeout.
     returncode, _, _ = run('kubectl version', DEFAULT_TIMEOUT)
     if returncode != 0:
-        msg = 'Cannot reach cluster with kubectl'
+        msg = 'Cannot reach cluster with kubectl: `kubectl version` either timed out or failed to connect (exit code {})'.format(returncode)
         if minishift:
             # Minishift needs special configuration for kubectl to work
             msg = msg + ". Did you do 'eval $(minishift oc-env)'?"

--- a/enterprise-suite/templates/backend-deployment.yaml
+++ b/enterprise-suite/templates/backend-deployment.yaml
@@ -90,6 +90,7 @@ spec:
             requests:
               cpu: {{ default .Values.defaultCPURequest .Values.esMonitorCPURequest }}
               memory: {{ default .Values.defaultMemoryRequest .Values.esMonitorMemoryRequest }}
+
           args:
             - --configPath=/etc/config/
             - --storagePath=/monitor-data/
@@ -99,6 +100,14 @@ spec:
             - --prometheusDomain={{ .Values.prometheusDomain }}
             - --alertmanagers={{ .Values.alertManagers }}
             - --defaultMonitorWarmup={{ .Values.consoleAPI.defaultMonitorWarmup }}
+            - --namespace=$(CONSOLE_NAMESPACE)
+
+          env:
+          - name: CONSOLE_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
@@ -111,15 +120,18 @@ spec:
             - name: prometheus-data-volume
               mountPath: /monitor-data
               subPath: monitor-data
+
           ports:
             - name: metrics
               containerPort: 8180
+
           readinessProbe:
             failureThreshold: 3
             httpGet:
               path: /status
               port: 8180
               scheme: HTTP
+
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -10,7 +10,7 @@ consoleUIConfig:
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-console
 esConsoleVersion: v1.0.7
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/console-api
-esMonitorVersion: v1.1.3
+esMonitorVersion: v1.1.4
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-grafana
 esGrafanaVersion: v0.2.4
 # prom/prometheus


### PR DESCRIPTION
- Uses console-api 1.1.4 with --namespace to fill in prometheus.yml
- Add gotest to check only a single metric from ksm exists (no copies)
- Increase lbc.py timeout - it was too low on higher latency
connections. Also try to improve its error message.

For https://github.com/lightbend/console-backend/issues/628