### PR TITLE
Fix debug-dump zipfile to contain logs

### DIFF
--- a/enterprise-suite/gotests/tests/ingress/ingress_test.go
+++ b/enterprise-suite/gotests/tests/ingress/ingress_test.go
@@ -86,7 +86,7 @@ var _ = Describe("minikube:ingress", func() {
 		Expect(err).To(Succeed())
 
 		httpClient := &http.Client{
-			Timeout: 10*time.Second,
+			Timeout: 10 * time.Second,
 		}
 		req, err := http.NewRequest("GET", fmt.Sprintf("http://%v/es-console", ip), nil)
 		Expect(err).To(Succeed())

--- a/enterprise-suite/gotests/tests/installer/installer_test.go
+++ b/enterprise-suite/gotests/tests/installer/installer_test.go
@@ -88,7 +88,7 @@ var _ = Describe("all:lbc.py", func() {
 		})
 	})
 
-	FContext("debug-dump", func() {
+	Context("debug-dump", func() {
 		It("should contain the pod logs", func() {
 			Expect(util.Cmd("/bin/bash", "-c", lbc.Path+" debug-dump --namespace="+args.ConsoleNamespace).
 				Timeout(0).Run()).To(Succeed())

--- a/enterprise-suite/gotests/tests/installer/installer_test.go
+++ b/enterprise-suite/gotests/tests/installer/installer_test.go
@@ -1,11 +1,14 @@
 package installer
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
+	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util/lbc"
 
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"
@@ -82,6 +85,42 @@ var _ = Describe("all:lbc.py", func() {
 			installer.AdditionalLBCArgs = []string{"--namespace=" + args.ConsoleNamespace}
 			installer.AdditionalHelmArgs = []string{"--namespace=my-busted-namespace"}
 			Expect(installer.Install()).ToNot(Succeed())
+		})
+	})
+
+	FContext("debug-dump", func() {
+		It("should contain the pod logs", func() {
+			Expect(util.Cmd("/bin/bash", "-c", lbc.Path+" debug-dump --namespace="+args.ConsoleNamespace).
+				Timeout(0).Run()).To(Succeed())
+
+			dir, err := ioutil.TempDir("", "lbcpytest")
+			fmt.Printf("%s\n", dir)
+			defer os.RemoveAll(dir)
+			if err != nil {
+				panic(err)
+			}
+			Expect(util.Cmd("/bin/bash", "-c", "mv *.zip "+dir+"/").Run()).To(Succeed())
+			files, err := ioutil.ReadDir(dir)
+			if err != nil {
+				panic(err)
+			}
+
+			Expect(files).To(HaveLen(1))
+			zipFile := dir + "/" + files[0].Name()
+			Expect(util.Cmd("/bin/bash", "-c", "cd "+dir+" && unzip "+zipFile).Run()).To(Succeed())
+
+			matches, err := filepath.Glob(dir + "/console-backend*prometheus-server.log")
+			if err != nil {
+				panic(err)
+			}
+			Expect(matches).To(HaveLen(1), "should have found prometheus-server.log")
+			promLogFile := matches[0]
+			contents, err := ioutil.ReadFile(promLogFile)
+			if err != nil {
+				panic(err)
+			}
+			Expect(string(contents)).To(ContainSubstring("Completed loading of configuration file"),
+				"%s should contain logs", promLogFile)
 		})
 	})
 })

--- a/enterprise-suite/gotests/tests/portforward/portforward_test.go
+++ b/enterprise-suite/gotests/tests/portforward/portforward_test.go
@@ -53,7 +53,7 @@ var _ = Describe("all:portforward", func() {
 
 		err := util.WaitUntilSuccess(util.SmallWait, func() error {
 			client := &http.Client{
-				Timeout: 10*time.Second,
+				Timeout: 10 * time.Second,
 			}
 			resp, err := client.Get(addr)
 			if err != nil {

--- a/enterprise-suite/gotests/util/alertmanager/alertmanager.go
+++ b/enterprise-suite/gotests/util/alertmanager/alertmanager.go
@@ -38,7 +38,7 @@ type Connection struct {
 func (a *Connection) Alerts() ([]Alert, error) {
 	addr := fmt.Sprintf("%v/api/v1/alerts", a.url)
 	client := &http.Client{
-		Timeout: 10*time.Second,
+		Timeout: 10 * time.Second,
 	}
 	resp, err := client.Get(addr)
 	if err != nil {

--- a/enterprise-suite/gotests/util/lbc/lbc.go
+++ b/enterprise-suite/gotests/util/lbc/lbc.go
@@ -11,8 +11,10 @@ import (
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/util"
 )
 
-const localChartPath = "../../../."
-const lbcPath = "../../../scripts/lbc.py"
+const (
+	localChartPath = "../../../."
+	Path           = "../../../scripts/lbc.py"
+)
 
 type Installer struct {
 	UsePersistentVolumes string
@@ -31,7 +33,7 @@ func DefaultInstaller() *Installer {
 }
 
 func (i *Installer) Install() error {
-	cmdArgs := []string{lbcPath, "install", "--local-chart", localChartPath,
+	cmdArgs := []string{Path, "install", "--local-chart", localChartPath,
 		"--namespace", args.ConsoleNamespace,
 		"--set prometheusDomain=console-backend-e2e.io"}
 	if i.ForceDeletePVCs {
@@ -87,7 +89,7 @@ func logDebugInfo(namespace string) {
 }
 
 func Verify(namespace, tillerNamespace string) error {
-	cmd := util.Cmd(lbcPath, "verify", "--namespace", namespace)
+	cmd := util.Cmd(Path, "verify", "--namespace", namespace)
 	if tillerNamespace != "" {
 		cmd = cmd.Env("TILLER_NAMESPACE", tillerNamespace)
 	}

--- a/enterprise-suite/gotests/util/urls/urls.go
+++ b/enterprise-suite/gotests/util/urls/urls.go
@@ -21,7 +21,7 @@ func Get200(url string) (Result, error) {
 
 	err := util.WaitUntilSuccess(util.SmallWait, func() error {
 		client := &http.Client{
-			Timeout: 10*time.Second,
+			Timeout: 10 * time.Second,
 		}
 		resp, err := client.Get(url)
 		if err != nil {
@@ -51,7 +51,7 @@ func Get(url string, followRedirects bool) (Result, error) {
 
 	err := util.WaitUntilSuccess(util.SmallWait, func() error {
 		client := &http.Client{
-			Timeout: 10*time.Second,
+			Timeout: 10 * time.Second,
 		}
 		if !followRedirects {
 			client.CheckRedirect = func(req *http.Request, via []*http.Request) error {


### PR DESCRIPTION
It was incorrectly storing `kubectl get pods` in the logfiles. This is
fixed now. A workaround prior to this change is to use `--print` which
works correctly.

Also improve debug-dump logs. Print to stderr as its collecting
information, so it's clear it's not just hanging.

Also limit logs to last 250 lines to prevent giant debug files.

Also fix debug-dump failing if logs fail to retrieve, which can happen
when a pod is crash looping.

Fix https://github.com/lightbend/console-backend/issues/694