### PR TITLE
Make install script backwards compatible with old deployment names

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -645,7 +645,7 @@ def check_install(external_alertmanager=False):
 
     status_ok = check_deployments(CONSOLE_DEPLOYMENTS) 
     if not status_ok:
-        printerr('\nIt appears you are running older version of console, checking old deployment names...\n')
+        printerr('\nIt appears you might be running older version of console, checking old deployment names...\n')
         status_ok = check_deployments(CONSOLE_DEPLOYMENTS_OLD)
 
     if status_ok:

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -41,6 +41,14 @@ CONSOLE_DEPLOYMENTS = [
     'prometheus-kube-state-metrics',
 ]
 
+# Deployments for 1.1 and older versions of Console, install script needs to be compatible
+CONSOLE_DEPLOYMENTS_OLD = [
+    'es-console',
+    'grafana-server',
+    'prometheus-server',
+    'prometheus-kube-state-metrics',
+]
+
 # Alertmanager deployment, this check can be turned off with --external-alertmanager
 CONSOLE_ALERTMANAGER_DEPLOYMENT = 'prometheus-alertmanager'
 
@@ -625,14 +633,20 @@ def check_install(external_alertmanager=False):
             printerr('Unable to check deployment {} status'.format(name))
         return False
 
-    status_ok = True
+    def check_deployments(deployments):
+        status_ok = True
+        deps = deployments
+        if not external_alertmanager:
+            deps = deps + [CONSOLE_ALERTMANAGER_DEPLOYMENT]
 
-    deps = CONSOLE_DEPLOYMENTS
-    if not external_alertmanager:
-        deps = deps + [CONSOLE_ALERTMANAGER_DEPLOYMENT]
+        for dep in deps:
+            status_ok &= deployment_running(dep)
+        return status_ok
 
-    for dep in deps:
-        status_ok &= deployment_running(dep)
+    status_ok = check_deployments(CONSOLE_DEPLOYMENTS) 
+    if not status_ok:
+        printerr('\nIt appears you are running older version of console, checking old deployment names...\n')
+        status_ok = check_deployments(CONSOLE_DEPLOYMENTS_OLD)
 
     if status_ok:
         printerr('Your Lightbend Console seems to be running fine!')

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -339,6 +339,19 @@ class HelmCommandsTest(unittest.TestCase):
         expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-alertmanager --no-headers',
                    stdout='prometheus-alertmanager 1 1 1 1 15m')
 
+        # Installer will check old deployment names if the new ones fail
+        expect_cmd(r'kubectl --namespace monitoring get deploy/es-console --no-headers',
+                   stdout='console-backend 2 2 2 2 15m')
+        # Grafana is not running
+        expect_cmd(r'kubectl --namespace monitoring get deploy/grafana-server --no-headers',
+                   stdout='console-frontend 1 1 1 0 15m')
+        expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-server --no-headers',
+                   stdout='grafana 1 1 1 1 15m')
+        expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-kube-state-metrics --no-headers',
+                   stdout='prometheus-kube-state-metrics 1 1 1 1 15m')
+        expect_cmd(r'kubectl --namespace monitoring get deploy/prometheus-alertmanager --no-headers',
+                   stdout='prometheus-alertmanager 1 1 1 1 15m') 
+
         # Expect verify to fail
         with self.assertRaises(TestFailException):
             lbc.main(['verify', '--skip-checks', '--namespace=monitoring'])


### PR DESCRIPTION
For https://github.com/lightbend/console-backend/issues/699

This makes install script backwards compatible with old deployment names, for example, those used in 1.1 and previous versions.

Instead of parsing version string to decide what to check, I opted to use a more fool-proof approach - check old names if new ones fail. This prints out more stuff when `verify` is done on old versions, but should work the same as the current installer in future versions.