### PR TITLE
Fix lbc.py to reliably fetch remote charts

### DIFF
--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -35,7 +35,7 @@ purge-console-openshift: purge-console
 purge-console:
 	-TILLER_NAMESPACE=$(TILLER_NAMESPACE) ../scripts/lbc.py uninstall --delete-pvcs
 
-ginkgo_args := -v -r -compilers=2 --progress --failFast --randomizeAllSpecs --slowSpecThreshold=30 -- --namespace=$(NAMESPACE) --tiller-namespace=$(TILLER_NAMESPACE)
+ginkgo_args := -r -compilers=2 --progress --failFast --randomizeAllSpecs --slowSpecThreshold=30 -- --namespace=$(NAMESPACE) --tiller-namespace=$(TILLER_NAMESPACE)
 
 .PHONY: run-tests-minikube
 run-tests-minikube:

--- a/enterprise-suite/gotests/tests/installer/installer_test.go
+++ b/enterprise-suite/gotests/tests/installer/installer_test.go
@@ -89,7 +89,7 @@ var _ = Describe("all:lbc.py", func() {
 	})
 
 	Context("export yaml", func() {
-		It("should be able to export the yaml for a remote chart", func() {
+		It("should be able to export the console yaml for a remote chart", func() {
 			installer := lbc.DefaultInstaller()
 			installer.AdditionalLBCArgs = []string{"--export-yaml=console", "--version=1.1.0"}
 			installer.LocalChart = false
@@ -97,7 +97,7 @@ var _ = Describe("all:lbc.py", func() {
 			Expect(installer.Install()).To(Succeed())
 		})
 
-		It("should be able to export the credentials for a remote chart", func() {
+		It("should be able to export the Lightbend credentials for a remote chart", func() {
 			installer := lbc.DefaultInstaller()
 			installer.AdditionalLBCArgs = []string{"--export-yaml=creds", "--version=1.1.0"}
 			// jsravn: This is necessary to prevent leaking credentials in builds.
@@ -105,17 +105,16 @@ var _ = Describe("all:lbc.py", func() {
 			installer.LocalChart = false
 			installer.HelmWait = false
 			Expect(installer.Install()).To(Succeed())
-			Expect(false).To(BeTrue())
 		})
 
-		It("should be able to export the yaml for the local chart", func() {
+		It("should be able to export the console yaml for a local chart", func() {
 			installer := lbc.DefaultInstaller()
 			installer.AdditionalLBCArgs = []string{"--export-yaml=console"}
 			installer.HelmWait = false
 			Expect(installer.Install()).To(Succeed())
 		})
 
-		It("should be able to export the yaml for the local chart", func() {
+		It("should be able to export the Lightbend credentials for a local chart", func() {
 			installer := lbc.DefaultInstaller()
 			installer.AdditionalLBCArgs = []string{"--export-yaml=creds"}
 			// jsravn: This is necessary to prevent leaking credentials in builds.

--- a/enterprise-suite/gotests/tests/installer/installer_test.go
+++ b/enterprise-suite/gotests/tests/installer/installer_test.go
@@ -88,6 +88,43 @@ var _ = Describe("all:lbc.py", func() {
 		})
 	})
 
+	Context("export yaml", func() {
+		It("should be able to export the yaml for a remote chart", func() {
+			installer := lbc.DefaultInstaller()
+			installer.AdditionalLBCArgs = []string{"--export-yaml=console", "--version=1.1.0"}
+			installer.LocalChart = false
+			installer.HelmWait = false
+			Expect(installer.Install()).To(Succeed())
+		})
+
+		It("should be able to export the credentials for a remote chart", func() {
+			installer := lbc.DefaultInstaller()
+			installer.AdditionalLBCArgs = []string{"--export-yaml=creds", "--version=1.1.0"}
+			// jsravn: This is necessary to prevent leaking credentials in builds.
+			installer.AdditionalHelmArgs = []string{"> /dev/null"}
+			installer.LocalChart = false
+			installer.HelmWait = false
+			Expect(installer.Install()).To(Succeed())
+			Expect(false).To(BeTrue())
+		})
+
+		It("should be able to export the yaml for the local chart", func() {
+			installer := lbc.DefaultInstaller()
+			installer.AdditionalLBCArgs = []string{"--export-yaml=console"}
+			installer.HelmWait = false
+			Expect(installer.Install()).To(Succeed())
+		})
+
+		It("should be able to export the yaml for the local chart", func() {
+			installer := lbc.DefaultInstaller()
+			installer.AdditionalLBCArgs = []string{"--export-yaml=creds"}
+			// jsravn: This is necessary to prevent leaking credentials in builds.
+			installer.AdditionalHelmArgs = []string{"> /dev/null"}
+			installer.HelmWait = false
+			Expect(installer.Install()).To(Succeed())
+		})
+	})
+
 	Context("debug-dump", func() {
 		It("should contain the pod logs", func() {
 			Expect(util.Cmd("/bin/bash", "-c", lbc.Path+" debug-dump --namespace="+args.ConsoleNamespace).

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -24,6 +24,7 @@ import base64
 import urllib2 as url
 import json
 import time
+import glob
 from distutils.version import LooseVersion
 
 # Minimum required dependency versions
@@ -475,7 +476,7 @@ def install(creds_file):
             execute('helm repo add {} {}'.format(args.repo_name, args.repo))
             execute('helm repo update')
             tempdir = make_fetchdir()
-            chart_file = "{}/{}".format(tempdir, fetch_remote_chart(tempdir))
+            chart_file = fetch_remote_chart(tempdir)
 
         if args.export_yaml:
             # Tillerless path - renders kubernetes resources and prints to stdout.
@@ -820,7 +821,7 @@ def fetch_remote_chart(destdir):
         printerr("unable to reach helm repo: ", chart_url)
         printerr(fetch_stderr)
         fail("")
-    chart = os.listdir(destdir)[0]
+    chart = glob.glob(destdir + '/enterprise-suite-*.tgz')[0]
     return chart
 
 


### PR DESCRIPTION
On some systems it was returning the 'helm-charts' index file instead of
the tarball. Use a specific glob instead to ensure we always return the
tarball name.

For https://github.com/lightbend/console-backend/issues/700