### PR TITLE
Fix lbc.py helm fetch

### DIFF
--- a/enterprise-suite/gotests/README.md
+++ b/enterprise-suite/gotests/README.md
@@ -12,10 +12,6 @@ kubectl create serviceaccount --namespace kube-system tiller
 kubectl create clusterrolebinding kube-system:tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
 helm init --wait --service-account tiller --tiller-namespace=kube-system
 ```
-Alternatively, you can use `go-tests` and `go-tests-start-minikube` targets in the `enterprise-suite/Makefile`.
-
-Running all tests locally:
-`ginkgo -r`
 
 If Tiller is installed in other namespace than `kube-system`, you can specify that with a flag:
 `ginkgo -r -- --tiller-namespace=lightbend-test`
@@ -24,6 +20,8 @@ Note: this is not a ginkgo flag, but a custom flag in the test suites so it come
 Running only minikube or openshift:
 `ginkgo -r --skip=.*minikube.*`
 `ginkgo -r --skip=.*openshift.*`
+
+You can also use `gotests-minikube` and `gotests-openshift` makefile targets in `enterprise-suite/Makefile`.
 
 Running a single test suite:
 `ginkgo tests/prometheus`

--- a/enterprise-suite/gotests/tests/installer/installer_test.go
+++ b/enterprise-suite/gotests/tests/installer/installer_test.go
@@ -59,7 +59,11 @@ var _ = Describe("all:lbc.py", func() {
 			installer.LocalChart = false
 			installer.AdditionalLBCArgs = []string{"--version=1.1"}
 
-			Expect(installer.Install()).To(Succeed())
+			// The test fails currently because version 1.1 doesn't have values-dump.yaml needed to compute helm values
+			want := "Found unexpected warning line: \"warning: unable to determine computed helm values - this may lead to incorrect warning\""
+			err := installer.Install()
+			Expect(err).NotTo(Succeed())
+			Expect(err.Error()).To(Equal(want))
 		})
 	})
 

--- a/enterprise-suite/gotests/tests/installer/installer_test.go
+++ b/enterprise-suite/gotests/tests/installer/installer_test.go
@@ -60,7 +60,7 @@ var _ = Describe("all:lbc.py", func() {
 			installer.AdditionalLBCArgs = []string{"--version=1.1"}
 
 			// The test fails currently because version 1.1 doesn't have values-dump.yaml needed to compute helm values
-			want := "Found unexpected warning line: \"warning: unable to determine computed helm values - this may lead to incorrect warning\""
+			want := "Found unexpected warning line: \"warning: unable to determine computed helm values - this may lead to incorrect warnings\""
 			err := installer.Install()
 			Expect(err).NotTo(Succeed())
 			Expect(err.Error()).To(Equal(want))

--- a/enterprise-suite/gotests/tests/installer/installer_test.go
+++ b/enterprise-suite/gotests/tests/installer/installer_test.go
@@ -51,6 +51,18 @@ var _ = Describe("all:lbc.py", func() {
 		Expect(err).To(Succeed())
 	})
 
+	Context("install", func() {
+		// Note: this test depends on remote service being up, consider disabling it if it causes problems
+		It("should be able to install a remote chart at specified version", func() {
+			installer := lbc.DefaultInstaller()
+			installer.FailOnWarnings = true
+			installer.LocalChart = false
+			installer.AdditionalLBCArgs = []string{"--version=1.1"}
+
+			Expect(installer.Install()).To(Succeed())
+		})
+	})
+
 	Context("upgrades", func() {
 		Context("disable persistent volumes", func() {
 			var installer *lbc.Installer

--- a/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
+++ b/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
@@ -141,7 +141,10 @@ var _ = Describe("all:prometheus", func() {
 	Context("kube-state-metrics", func() {
 		It("should only scrape a single instance", func() {
 			query := fmt.Sprintf(`count(kube_pod_status_ready{namespace="%s", es_workload="console-backend", condition="true"}) == 1`, args.ConsoleNamespace)
-			Expect(prom.HasData(query)).To(Succeed())
+			err := util.WaitUntilSuccess(util.SmallWait, func() error {
+				return prom.HasData(query)
+			})
+			Expect(err).To(Succeed())
 		})
 	})
 

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -501,6 +501,7 @@ def install(creds_file):
             # Tiller path - installs console directly to a k8s cluster in a given namespace
 
             # Calculate computed values for chart to be installed.
+            # Note: older versions (1.1 and older) will not have dump-values.yaml, so warning will be printed
             template_args = prune_template_args(helm_args)
             rc, template_stdout, template_stderr = run('helm template -x templates/dump-values.yaml {} {}'.
                                                        format(template_args, chart_file),

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -368,7 +368,7 @@ def check_pv_usage(uninstalling=False):
                                                        DEFAULT_TIMEOUT, show_stderr=False)
 
     if 'usePersistentVolumes' not in values:
-        printerr("warn: can't determine the value of usePersistentVolumes, unable to parse helm values")
+        printerr("warning: can't determine the value of usePersistentVolumes, unable to parse helm values")
         return
 
     wants_pvcs = values['usePersistentVolumes'] is True
@@ -459,7 +459,7 @@ def install(creds_file):
 
         if ns_args.namespace is not None:
             if args.namespace != "lightbend" and args.namespace != ns_args.namespace:
-                printerr("WARNING: Conflicting namespace values provided in arguments {} and {} ".format(
+                printerr("warning: conflicting namespace values provided in arguments {} and {} ".format(
                     args.namespace, ns_args.namespace))
                 fail("Invoke again with correct namespace value...")
             namespace_arg = ""
@@ -507,14 +507,14 @@ def install(creds_file):
                                                        show_stderr=False)
             global values
             if rc != 0:
-                printerr("warn: unable to determine computed helm values - this may lead to incorrect warnings")
+                printerr("warning: unable to determine computed helm values - this may lead to incorrect warnings")
                 values = {}
             else:
                 try:
                     computed = template_stdout.splitlines()[-2][2:]
                     values = json.loads(computed)
                 except Exception as e:
-                    printerr("warn: unable to parse helm values - this may lead to incorrect warnings")
+                    printerr("warning: unable to parse helm values - this may lead to incorrect warnings")
                     printerr(e)
                     values = {}
 

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -828,8 +828,10 @@ def fetch_remote_chart(destdir):
     extra_args = ""
     if args.version:
         extra_args = "--version %s" % args.version
-    chart_url = 'helm fetch --destination {} {} {} {}/{}'\
-        .format(destdir, extra_args, args.repo, args.repo_name, args.chart)
+    # `helm repo add & helm repo update` is always done before, inside install(),
+    # so it's safe to use this form of helm fetch here`
+    chart_url = 'helm fetch --destination {} {} {}/{}'\
+        .format(destdir, extra_args, args.repo_name, args.chart)
     rc, fetch_stdout, fetch_stderr = run(chart_url, DEFAULT_TIMEOUT, show_stderr=False)
     if rc != 0:
         printerr("unable to reach helm repo: ", chart_url)

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -133,7 +133,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_export_yaml_console(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template --name enterprise-suite --namespace lightbend\s+\S+\.tgz')
         lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console'])
 
@@ -144,14 +144,14 @@ class HelmCommandsTest(unittest.TestCase):
     def test_export_yaml_creds(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template --name enterprise-suite --namespace lightbend  --execute templates/commercial-credentials\.yaml\s+--values \S+ \S+\.tgz')
         lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--creds='+self.creds_file, '--export-yaml=creds'])
 
     def test_install(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend\s+--values \S+')
@@ -160,7 +160,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_install_wait(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend\s+--values \S+\s+--wait')
@@ -183,7 +183,7 @@ class HelmCommandsTest(unittest.TestCase):
         # Failed previous install, no PVCs or clusterroles found for reuse
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=0,
                    stdout='LAST DEPLOYED: Tue Nov 13 09:59:46 2018\nNAMESPACE: lightbend\nSTATUS: FAILED\nNOTES: blah')
@@ -193,7 +193,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_install_not_finished(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=0,
                    stdout='LAST DEPLOYED: Tue Nov 13 09:59:46 2018\nNAMESPACE: lightbend\nSTATUS: PENDING_INSTALL\nNOTES: blah')
@@ -205,7 +205,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_upgrade(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=0)
         expect_cmd(r'helm upgrade enterprise-suite es-repo/enterprise-suite\s+--values \S+')
@@ -214,7 +214,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_force_install(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=0)
         expect_cmd(r'helm delete --purge enterprise-suite')
@@ -224,7 +224,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_helm_args(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend\s+--values \S+ --set minikube=true --fakearg')
@@ -233,7 +233,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_helm_args_namespace(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --values \S+ --set minikube=true --fakearg --namespace=foobar')
@@ -242,7 +242,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_helm_args_namespace_val(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --values \S+ --set minikube=true --fakearg --namespace foobar')
@@ -264,7 +264,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_helm_set(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --values \S+ --set minikube=true --set usePersistentVolumes=true ')
@@ -273,7 +273,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_helm_set_array(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --values \S+ --set alertmanagers=alertmgr-00\\,alertmgr-01\\,alertmgr-02 ')
@@ -283,7 +283,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_specify_version(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --version 1\.0\.0-rc\.9 --values \S+')
@@ -298,7 +298,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_install_override_repo(self):
         expect_cmd(r'helm repo add es-repo https://repo.bintray.com/helm')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.bintray.com/helm es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --values \S+')
@@ -307,7 +307,7 @@ class HelmCommandsTest(unittest.TestCase):
     def test_install_override_name(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
-        expect_cmd(r'helm fetch .* https://repo.lightbend.com/helm-charts es-repo/enterprise-suite')
+        expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         expect_cmd(r'helm template .*')
         expect_cmd(r'helm status lb-console', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name lb-console --namespace lightbend --values \S+')


### PR DESCRIPTION
Fixes https://github.com/lightbend/console-backend/issues/702

This PR changes how lbc.py does `helm fetch` and introduces new gotest that checks for warnings generated when trying to install remote chart at specified version.

The story is still incomplete because Console 1.1 helm chart doesn't have `dump-values.yaml` file needed for computing helm values. The test allows that warning to happen for now.