### PR TITLE
Update console-api to v1.1.7 with renamed Kafka monitors

### DIFF
--- a/enterprise-suite/.helmignore
+++ b/enterprise-suite/.helmignore
@@ -19,6 +19,7 @@ README.md
 *.swp
 *.bak
 *.tmp
+*.pyc
 *~
 # Various IDEs
 .project

--- a/enterprise-suite/console-api/default-monitors.json
+++ b/enterprise-suite/console-api/default-monitors.json
@@ -83,7 +83,7 @@
           "filters": {
             "quantile": "0.5"
           },
-          "period": "15m",
+          "period": "5m",
           "minslope": "0.1",
           "confidence": "1",
           "severity": {
@@ -492,7 +492,7 @@
           "alertDescription": "Circuit breaker {{$labels.circuit_breaker}} tripped on {{$labels.instance}}"
         }
       },
-      "kafka_consumer_throughput": {
+      "pipelines_kafka_consumer_throughput": {
         "monitorVersion": "1",
         "model": "sma",
         "parameters": {
@@ -510,7 +510,7 @@
           "alertDescription": "{{$labels.es_workload}} has unusual throughput on {{$labels.topic}}"
         }
       },
-      "kafka_producer_throughput": {
+      "pipelines_kafka_producer_throughput": {
         "monitorVersion": "1",
         "model": "sma",
         "parameters": {
@@ -528,7 +528,7 @@
           "alertDescription": "{{$labels.es_workload}} has unusual throughput on {{$labels.topic}}"
         }
       },
-      "kafka_consumer_lag": {
+      "pipelines_kafka_consumer_lag": {
         "monitorVersion": "1",
         "model": "growth",
         "parameters": {

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -11,7 +11,7 @@ consoleUIConfig:
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-console
 esConsoleVersion: v1.1.1
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/console-api
-esMonitorVersion: v1.1.6
+esMonitorVersion: v1.1.7
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-grafana
 esGrafanaVersion: v0.2.9
 # prom/prometheus


### PR DESCRIPTION
For https://github.com/lightbend/console-backend/issues/712

This updates console-api version to v1.1.7 with two new features:
- Renamed Kafka monitors to better indicate that they are specific to pipelines
- Reduced akka inbox monitor period to 5m