### PR TITLE
Bump grafana

### DIFF
--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -13,7 +13,7 @@ esConsoleVersion: v1.2.2
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/console-api
 esMonitorVersion: v1.2.2
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-grafana
-esGrafanaVersion: v0.2.11
+esGrafanaVersion: v0.2.12-rc1
 # prom/prometheus
 prometheusVersion: v2.9.2
 # jimmidyson/configmap-reload

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -13,7 +13,7 @@ esConsoleVersion: v1.2.2
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/console-api
 esMonitorVersion: v1.2.2
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-grafana
-esGrafanaVersion: v0.2.12-rc1
+esGrafanaVersion: v0.2.12
 # prom/prometheus
 prometheusVersion: v2.9.2
 # jimmidyson/configmap-reload


### PR DESCRIPTION
This fixes the upgrade issue when going from the plugin based grafana install.

This is the rc1. This PR depends on
https://github.com/lightbend/console-grafana/pull/60 and should be
updated once that is merged.