### PR TITLE
Store nightly charts in TTL bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
     - run: mkdir -p /tmp/resources
     - run: gpg --batch --passphrase ${GCS_DEC_KEY} --output /tmp/resources/es-repo-7c1fefe17951.json --decrypt resources/es-repo-7c1fefe17951.json.enc
     - setup_remote_docker
-    - run: scripts/deploy-to-gcs.sh
+    - run: GCS_BUCKET=lightbend-console-charts-nightly scripts/deploy-to-gcs.sh
     - run: scripts/trigger-build-helm-charts.sh
 
   deploy_demo:


### PR DESCRIPTION
This bucket expires objects after 14 days - so we should have no more
than 14 nightly charts in it.

For https://github.com/lightbend/console-backend/issues/740