### PR TITLE
Bump console api to 1.2.4

### DIFF
--- a/enterprise-suite/console-api/default-monitors.json
+++ b/enterprise-suite/console-api/default-monitors.json
@@ -122,40 +122,6 @@
           "docLink": "https://developer.lightbend.com/docs/console/current/monitors/akka.html#akka-processing-time"
         }
       },
-      "prometheus_notifications_dropped": {
-        "monitorVersion": "1",
-        "model": "threshold",
-        "parameters": {
-          "metric": "prometheus_notifications_dropped_rate",
-          "window": "10m",
-          "confidence": "0.25",
-          "severity": {
-            "warning": {
-              "comparator": ">",
-              "threshold": "0"
-            }
-          },
-          "alertSummary": "Prometheus dropping notifications",
-          "alertDescription": "Prometheus dropping alerts sent to Alertmanager"
-        }
-      },
-      "prometheus_notification_queue": {
-        "monitorVersion": "1",
-        "model": "threshold",
-        "parameters": {
-          "metric": "prometheus_notification_queue_percent",
-          "window": "10m",
-          "confidence": "0.5",
-          "severity": {
-            "warning": {
-              "comparator": ">",
-              "threshold": "50"
-            }
-          },
-          "alertSummary": "Prometheus alert queue filling",
-          "alertDescription": "Prometheus alert queue is staying over 50% full"
-        }
-      },
       "prometheus_rule_evaluation_failures": {
         "monitorVersion": "1",
         "model": "threshold",

--- a/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
+++ b/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
@@ -66,9 +66,8 @@ var _ = BeforeSuite(func() {
 	}
 
 	// wait until there's some scrapes finished
-	Expect(waitForScrapes("prometheus_notifications_dropped_rate")).To(Succeed())
-	Expect(waitForScrapes(`model{name="prometheus_notifications_dropped"}`)).To(Succeed())
 	Expect(waitForScrapes("kube_pod_info")).To(Succeed())
+	Expect(waitForScrapes("prometheus_rule_evaluation_failures_rate")).To(Succeed())
 })
 
 var _ = AfterSuite(func() {
@@ -92,8 +91,6 @@ var _ = Describe("all:prometheus", func() {
 		func(metric string) {
 			Expect(prom.AnyData(metric)).To(Succeed())
 		},
-		Metric("prometheus_notifications_dropped_rate"),
-		Metric("prometheus_notification_queue_percent"),
 		Metric("prometheus_rule_evaluation_failures_rate"),
 		Metric("prometheus_target_scrapes_exceeded_sample_limit_rate"),
 		Metric("prometheus_tsdb_reloads_failures_rate"),
@@ -107,8 +104,6 @@ var _ = Describe("all:prometheus", func() {
 			Expect(prom.AnyData(fmt.Sprintf(`model{name="%v"}`, metric))).To(Succeed())
 			Expect(prom.AnyData(fmt.Sprintf(`health{name="%v"}`, metric))).To(Succeed())
 		},
-		Metric("prometheus_notifications_dropped"),
-		Metric("prometheus_notification_queue"),
 		Metric("prometheus_rule_evaluation_failures"),
 		Metric("prometheus_target_too_many_metrics"),
 		Metric("prometheus_tsdb_reloads_failures"),

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -667,8 +667,9 @@ def debug_dump(args):
         if returncode == 0:
             return containers.split()
         else:
-            fail(failure_msg + 'unable to get containers in a pod {}'
+            printerr(failure_msg + 'unable to get containers in a pod {}'
                  .format(pod))
+            return []
 
     def write_log(archive, pod, container):
         returncode, logs_out, _ = run('kubectl --namespace {} logs {} -c {} --tail=250'

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -11,7 +11,7 @@ consoleUIConfig:
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-console
 esConsoleVersion: v1.2.6
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/console-api
-esMonitorVersion: v1.2.3
+esMonitorVersion: v1.2.4
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-grafana
 esGrafanaVersion: v0.3.0
 # prom/prometheus

--- a/operator/manifests/console_cr.yaml
+++ b/operator/manifests/console_cr.yaml
@@ -36,7 +36,7 @@ spec:
   esGrafanaVersion: v0.3.0
   esGrafanaVolumeSize: 32Gi
   esMonitorImage: '{{ .Values.imageCredentials.registry }}/enterprise-suite/console-api'
-  esMonitorVersion: v1.2.3
+  esMonitorVersion: v1.2.4
   exposeServices: false
   goDnsmasqImage: lightbend-docker-registry.bintray.io/lightbend/go-dnsmasq
   goDnsmasqVersion: v0.1.7-1


### PR DESCRIPTION
Removes the alertmanager related monitors, which don't make sense
without alertmanager being installed by default.