### PR TITLE
enable both TCP and UDP port in logstash

### DIFF
--- a/enterprise-suite/console-api/logstash.conf
+++ b/enterprise-suite/console-api/logstash.conf
@@ -3,6 +3,10 @@ input {
     port => 5000
     codec => json
   }
+  tcp {
+    port => 5000
+    codec => json
+  }
 }
 
 output {

--- a/enterprise-suite/templates/backend-service-api.yaml
+++ b/enterprise-suite/templates/backend-service-api.yaml
@@ -19,7 +19,11 @@ spec:
     - name: kibana
       port: 5601
       targetPort: 5601
-    - name: logstash
+    - name: logstash-tcp
+      port: 5000
+      targetPort: 5000
+      protocol: TCP
+    - name: logstash-udp
       port: 5000
       targetPort: 5000
       protocol: UDP

--- a/enterprise-suite/templates/backend-service-api.yaml
+++ b/enterprise-suite/templates/backend-service-api.yaml
@@ -22,6 +22,7 @@ spec:
     - name: logstash
       port: 5000
       targetPort: 5000
+      protocol: UDP
   selector:
     app.kubernetes.io/name: {{ template "name" . }}
     app.kubernetes.io/component: console-backend


### PR DESCRIPTION
After discussed with @jsravn and @pvlugter  , we feel that TCP logstash connection is better over UDP.  Support both TCP and UDP for better compatibility. 

I have validated that both TCP and UDP work end to end with this setting.

The akka cluster changes for TCP connection is here https://github.com/lightbend/console-akka-cluster-explore/pull/15