### PR TITLE
Update CircleCI Golang Docker image to use latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
 
   backend_e2e_openshift:
     docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:latest
 
     environment:
       NAMESPACE: console-backend-go-tests


### PR DESCRIPTION
This is to try and fix the recent failures in `build_operator`:
* https://app.circleci.com/jobs/github/lightbend/console-charts/1065
* https://app.circleci.com/jobs/github/lightbend/console-charts/1072