### PR TITLE
Replace manual diagnostics with CircleCI Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           consider-branch: false
       - run: make -C enterprise-suite/gotests purge-console-openshift NAMESPACE=${NAMESPACE}
       - run: make -C enterprise-suite/gotests run-tests-openshift NAMESPACE=${NAMESPACE}
-      - diagnose-kubernetes:
+      - kubernetes-diagnostics/diagnose-kubernetes:
           namespace: "${NAMESPACE}"
       - run: make -C enterprise-suite/gotests purge-console-openshift NAMESPACE=${NAMESPACE}
 
@@ -60,7 +60,7 @@ jobs:
       - run: make -C enterprise-suite install-helm TILLER_NAMESPACE=${NAMESPACE}
       - run: make -C enterprise-suite/gotests setup-tools
       - run: make -C enterprise-suite/gotests run-tests-minikube NAMESPACE=${NAMESPACE}
-      - diagnose-kubernetes:
+      - kubernetes-diagnostics/diagnose-kubernetes:
           namespace: "${NAMESPACE}"
 
   frontend_e2e_minishift:
@@ -84,7 +84,7 @@ jobs:
       - run: scripts/setup-minikube-for-linux.sh
       - run: curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
       - run: make -C enterprise-suite frontend-tests1
-      - diagnose-kubernetes:
+      - kubernetes-diagnostics/diagnose-kubernetes:
           namespace: "${NAMESPACE}"
       - store_artifacts:
           path: enterprise-suite/tests/e2e/cypress/videos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,22 +4,24 @@ orbs:
   # https://circleci.com/orbs/registry/orb/eddiewebb/queue
   queue: eddiewebb/queue@1.1.3
   run-with-retry: kimh/run-with-retry@1.0.0
+  # TODO: Move this to the lightbend namespace once someone with permissions has created it.
+  kubernetes-diagnostics: bottech/kubernetes-diagnostics@0.0.4
 
 jobs:
   unit_tests:
     docker:
-    - image: circleci/buildpack-deps:stretch-curl
+      - image: circleci/buildpack-deps:stretch-curl
 
     steps:
-    - checkout
-    - run: scripts/setup-tools-for-debian.sh
-    - run: make -C enterprise-suite test
-    - run: make -C enterprise-suite check-default-monitors-sync
-    - run: echo success!
+      - checkout
+      - run: scripts/setup-tools-for-debian.sh
+      - run: make -C enterprise-suite test
+      - run: make -C enterprise-suite check-default-monitors-sync
+      - run: echo success!
 
   backend_e2e_openshift:
     docker:
-    - image: circleci/golang:1.13
+      - image: circleci/golang:1.13
 
     environment:
       NAMESPACE: console-backend-go-tests
@@ -27,15 +29,17 @@ jobs:
     working_directory: /go/src/github.com/lightbend/console-charts
 
     steps:
-    - checkout
-    - run: scripts/setup-tools-for-debian.sh
-    - run: scripts/setup-openshift.sh ${OC_GOTESTS_TOKEN} console-backend-go-tests
-    - run: make -C enterprise-suite/gotests setup-tools
-    - queue/until_front_of_line:
-        consider-branch: false
-    - run: make -C enterprise-suite/gotests purge-console-openshift NAMESPACE=${NAMESPACE}
-    - run: make -C enterprise-suite/gotests run-tests-openshift NAMESPACE=${NAMESPACE}
-    - run: make -C enterprise-suite/gotests purge-console-openshift NAMESPACE=${NAMESPACE}
+      - checkout
+      - run: scripts/setup-tools-for-debian.sh
+      - run: scripts/setup-openshift.sh ${OC_GOTESTS_TOKEN} console-backend-go-tests
+      - run: make -C enterprise-suite/gotests setup-tools
+      - queue/until_front_of_line:
+          consider-branch: false
+      - run: make -C enterprise-suite/gotests purge-console-openshift NAMESPACE=${NAMESPACE}
+      - run: make -C enterprise-suite/gotests run-tests-openshift NAMESPACE=${NAMESPACE}
+      - diagnose-kubernetes:
+          namespace: "${NAMESPACE}"
+      - run: make -C enterprise-suite/gotests purge-console-openshift NAMESPACE=${NAMESPACE}
 
   backend_e2e_minishift:
     machine:
@@ -48,204 +52,207 @@ jobs:
     working_directory: /home/circleci/go/src/github.com/lightbend/console-charts
 
     steps:
-    - checkout
-    - run: echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
-    - run: echo $PATH
-    - run: scripts/setup-tools-for-debian.sh
-    - run: scripts/setup-minikube-for-linux.sh
-    - run: make -C enterprise-suite install-helm TILLER_NAMESPACE=${NAMESPACE}
-    - run: make -C enterprise-suite/gotests setup-tools
-    - run: make -C enterprise-suite/gotests run-tests-minikube NAMESPACE=${NAMESPACE}
+      - checkout
+      - run: echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+      - run: echo $PATH
+      - run: scripts/setup-tools-for-debian.sh
+      - run: scripts/setup-minikube-for-linux.sh
+      - run: make -C enterprise-suite install-helm TILLER_NAMESPACE=${NAMESPACE}
+      - run: make -C enterprise-suite/gotests setup-tools
+      - run: make -C enterprise-suite/gotests run-tests-minikube NAMESPACE=${NAMESPACE}
+      - diagnose-kubernetes:
+          namespace: "${NAMESPACE}"
 
   frontend_e2e_minishift:
     machine:
       image: ubuntu-1604:201903-01
 
     steps:
-    - checkout
-    - run:
-        name: Install node@9.4.0
-        command: |
-          set +e
-          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
-          export NVM_DIR="/opt/circleci/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-          nvm install v9.4.0
-          nvm alias default v9.4.0
-          echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-          echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-    - run: scripts/setup-tools-for-debian.sh
-    - run: scripts/setup-minikube-for-linux.sh
-    - run: curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
-    - run: make -C enterprise-suite frontend-tests1
-
-    - store_artifacts:
-        path: enterprise-suite/tests/e2e/cypress/videos
+      - checkout
+      - run:
+          name: Install node@9.4.0
+          command: |
+            set +e
+            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm install v9.4.0
+            nvm alias default v9.4.0
+            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+            echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
+      - run: scripts/setup-tools-for-debian.sh
+      - run: scripts/setup-minikube-for-linux.sh
+      - run: curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
+      - run: make -C enterprise-suite frontend-tests1
+      - diagnose-kubernetes:
+          namespace: "${NAMESPACE}"
+      - store_artifacts:
+          path: enterprise-suite/tests/e2e/cypress/videos
 
   whitesource:
     docker:
-    - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:8-jdk
 
     steps:
-    - checkout
-    - setup_remote_docker
-    - run: scripts/setup-tools-for-debian.sh
-    - run: scripts/pull-console-images.sh
-    - run: curl -sLJO https://github.com/whitesource/fs-agent-distribution/raw/master/standAlone/whitesource-fs-agent.jar
-    - run: java -version
-    - run: java -jar whitesource-fs-agent.jar -apiKey ${WHITESOURCE_API_KEY} -c enterprise-suite/.ws.conf
+      - checkout
+      - setup_remote_docker
+      - run: scripts/setup-tools-for-debian.sh
+      - run: scripts/pull-console-images.sh
+      - run: curl -sLJO https://github.com/whitesource/fs-agent-distribution/raw/master/standAlone/whitesource-fs-agent.jar
+      - run: java -version
+      - run: java -jar whitesource-fs-agent.jar -apiKey ${WHITESOURCE_API_KEY} -c enterprise-suite/.ws.conf
 
   release:
     docker:
-    - image: circleci/buildpack-deps:stretch-curl
+      - image: circleci/buildpack-deps:stretch-curl
 
     steps:
-    - checkout
-    - queue/until_front_of_line:
-        consider-branch: false
-    - run: scripts/setup-tools-for-debian.sh
-    - run: scripts/set-chart-version.sh enterprise-suite ${CIRCLE_TAG#v}
-    - run: make -C enterprise-suite package
-    - run: mkdir -p /tmp/resources
-    - run: gpg --batch --passphrase ${GCS_DEC_KEY} --output /tmp/resources/es-repo-7c1fefe17951.json --decrypt resources/es-repo-7c1fefe17951.json.enc
-    - setup_remote_docker
-    - run: scripts/deploy-to-gcs.sh
-    - run: scripts/trigger-build-helm-charts.sh
+      - checkout
+      - queue/until_front_of_line:
+          consider-branch: false
+      - run: scripts/setup-tools-for-debian.sh
+      - run: scripts/set-chart-version.sh enterprise-suite ${CIRCLE_TAG#v}
+      - run: make -C enterprise-suite package
+      - run: mkdir -p /tmp/resources
+      - run: gpg --batch --passphrase ${GCS_DEC_KEY} --output /tmp/resources/es-repo-7c1fefe17951.json --decrypt resources/es-repo-7c1fefe17951.json.enc
+      - setup_remote_docker
+      - run: scripts/deploy-to-gcs.sh
+      - run: scripts/trigger-build-helm-charts.sh
 
   release_nightly:
     docker:
-    - image: circleci/buildpack-deps:stretch-curl
+      - image: circleci/buildpack-deps:stretch-curl
 
     steps:
-    - checkout
-    - queue/until_front_of_line:
-        consider-branch: false
-    - run: scripts/setup-tools-for-debian.sh
-    - run: scripts/set-chart-version.sh enterprise-suite $(scripts/get-nightly-version.sh)
-    - run: make -C enterprise-suite package
-    - run: mkdir -p /tmp/resources
-    - run: gpg --batch --passphrase ${GCS_DEC_KEY} --output /tmp/resources/es-repo-7c1fefe17951.json --decrypt resources/es-repo-7c1fefe17951.json.enc
-    - setup_remote_docker
-    - run: GCS_BUCKET=lightbend-console-charts-nightly scripts/deploy-to-gcs.sh
-    - run: scripts/trigger-build-helm-charts.sh
+      - checkout
+      - queue/until_front_of_line:
+          consider-branch: false
+      - run: scripts/setup-tools-for-debian.sh
+      - run: scripts/set-chart-version.sh enterprise-suite $(scripts/get-nightly-version.sh)
+      - run: make -C enterprise-suite package
+      - run: mkdir -p /tmp/resources
+      - run: gpg --batch --passphrase ${GCS_DEC_KEY} --output /tmp/resources/es-repo-7c1fefe17951.json --decrypt resources/es-repo-7c1fefe17951.json.enc
+      - setup_remote_docker
+      - run: GCS_BUCKET=lightbend-console-charts-nightly scripts/deploy-to-gcs.sh
+      - run: scripts/trigger-build-helm-charts.sh
 
   deploy_demo:
     docker:
-    - image: circleci/buildpack-deps:stretch-curl
+      - image: circleci/buildpack-deps:stretch-curl
 
     steps:
-    - checkout
-    - queue/until_front_of_line:
-        consider-branch: false
-    - run: scripts/setup-tools-for-debian.sh
-    - run: scripts/set-chart-version.sh enterprise-suite ${CIRCLE_TAG#v}
-    - run: make -C enterprise-suite package
-    - run: scripts/setup-openshift.sh ${OC_DEMO_TOKEN} console-demo
-    - run: TILLER_NAMESPACE=console-demo enterprise-suite/scripts/lbc.py install --namespace=console-demo --local-chart=build/enterprise-suite-${CIRCLE_TAG#v}.tgz --set usePersistentStorage=yes
-    - run: scripts/deploy-chaos-apps.sh console-demo
+      - checkout
+      - queue/until_front_of_line:
+          consider-branch: false
+      - run: scripts/setup-tools-for-debian.sh
+      - run: scripts/set-chart-version.sh enterprise-suite ${CIRCLE_TAG#v}
+      - run: make -C enterprise-suite package
+      - run: scripts/setup-openshift.sh ${OC_DEMO_TOKEN} console-demo
+      - run: TILLER_NAMESPACE=console-demo enterprise-suite/scripts/lbc.py install --namespace=console-demo --local-chart=build/enterprise-suite-${CIRCLE_TAG#v}.tgz --set usePersistentStorage=yes
+      - run: scripts/deploy-chaos-apps.sh console-demo
 
   build_operator:
     machine:
       image: ubuntu-1604:201903-01
 
     steps:
-    - checkout
-    - run: scripts/setup-tools-for-debian.sh
-    - run: |
-        sudo rm -rf /usr/local/go
-        sudo add-apt-repository ppa:longsleep/golang-backports
-        sudo apt-get update
-        sudo apt-get install golang-go
-        go version
-    - run: scripts/setup-minikube-for-linux.sh
-    - run: make -C operator setup
-    # jsravn: Unfortunately, the operator-sdk output isn't deterministic, so this can occasionally fail (about 10% of the time).
-    # All we can do for now is retry.
-    - run-with-retry/run-with-retry:
-        command: make -C operator build check
-        sleep: 0
-        retry-count: 3
+      - checkout
+      - run: scripts/setup-tools-for-debian.sh
+      - run: |
+          sudo rm -rf /usr/local/go
+          sudo add-apt-repository ppa:longsleep/golang-backports
+          sudo apt-get update
+          sudo apt-get install golang-go
+          go version
+      - run: scripts/setup-minikube-for-linux.sh
+      - run: make -C operator setup
+      # jsravn: Unfortunately, the operator-sdk output isn't deterministic, so this can occasionally fail (about 10% of the time).
+      # All we can do for now is retry.
+      - run-with-retry/run-with-retry:
+          command: make -C operator build check
+          sleep: 0
+          retry-count: 3
 
   release_operator:
     machine:
       image: ubuntu-1604:201903-01
 
     steps:
-    - checkout
-    - run: scripts/setup-tools-for-debian.sh
-    - run: |
-        sudo rm -rf /usr/local/go
-        sudo add-apt-repository ppa:longsleep/golang-backports
-        sudo apt-get update
-        sudo apt-get install golang-go
-        go version
-    - run: scripts/setup-minikube-for-linux.sh
-    - run: scripts/set-chart-version.sh enterprise-suite ${CIRCLE_TAG#v}
-    - run: VERSION=${CIRCLE_TAG#v} make -C operator setup build release
+      - checkout
+      - run: scripts/setup-tools-for-debian.sh
+      - run: |
+          sudo rm -rf /usr/local/go
+          sudo add-apt-repository ppa:longsleep/golang-backports
+          sudo apt-get update
+          sudo apt-get install golang-go
+          go version
+      - run: scripts/setup-minikube-for-linux.sh
+      - run: scripts/set-chart-version.sh enterprise-suite ${CIRCLE_TAG#v}
+      - run: VERSION=${CIRCLE_TAG#v} make -C operator setup build release
 
 workflows:
   version: 2
   build:
     jobs:
-    - unit_tests
-    - build_operator
+      - unit_tests
+      - build_operator
 
-    # E2E Tests. Don't run on master, as they are too slow and cause excessive queuing. Will run on PRs only.
-    - backend_e2e_openshift:
-        requires:
-        - unit_tests
-        filters:
-          branches:
-            ignore: master
-    - backend_e2e_minishift:
-        requires:
-        - unit_tests
-        filters:
-          branches:
-            ignore: master
-    - frontend_e2e_minishift:
-        requires:
-        - unit_tests
-        filters:
-          branches:
-            ignore: master
+      # E2E Tests. Don't run on master, as they are too slow and cause excessive queuing. Will run on PRs only.
+      - backend_e2e_openshift:
+          requires:
+            - unit_tests
+          filters:
+            branches:
+              ignore: master
+      - backend_e2e_minishift:
+          requires:
+            - unit_tests
+          filters:
+            branches:
+              ignore: master
+      - frontend_e2e_minishift:
+          requires:
+            - unit_tests
+          filters:
+            branches:
+              ignore: master
 
-    # Whitesource, release, and deploy happens on a tag only.
-    - whitesource:
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /v.*/
+      # Whitesource, release, and deploy happens on a tag only.
+      - whitesource:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/
 
-    - release:
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /v.*/
+      - release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/
 
-    - deploy_demo:
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /v.*/
+      - deploy_demo:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/
 
-    - release_operator:
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /v.*/
+      - release_operator:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/
 
   nightly:
     triggers:
-    - schedule:
-        cron: "0 0 * * * "
-        filters:
-          branches:
-            only: master
+      - schedule:
+          cron: "0 0 * * * "
+          filters:
+            branches:
+              only: master
 
     jobs:
-    - release_nightly
+      - release_nightly

--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -35,6 +35,7 @@ purge-console-openshift: purge-console
 purge-console:
 	-TILLER_NAMESPACE=$(TILLER_NAMESPACE) ../scripts/lbc.py uninstall --delete-pvcs
 
+# failFast is required in order to get CircleCI to perform the Kubernetes diagnostics accurately.
 ginkgo_args := -r -compilers=2 --progress --failFast --randomizeAllSpecs --slowSpecThreshold=30 -- --namespace=$(NAMESPACE) --tiller-namespace=$(TILLER_NAMESPACE)
 
 .PHONY: run-tests-minikube

--- a/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
+++ b/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
@@ -159,8 +159,6 @@ var _ = Describe("all:prometheus", func() {
 			err := util.WaitUntilSuccess(util.MedWait, func() error {
 				return prom.HasNData(1, query)
 			})
-			util.LogG("**** Debug flaky test")
-			util.LogDebugInfo()
 			Expect(err).To(Succeed())
 		})
 	})

--- a/enterprise-suite/gotests/util/lbc/lbc.go
+++ b/enterprise-suite/gotests/util/lbc/lbc.go
@@ -77,7 +77,6 @@ func (i *Installer) Install() error {
 	}
 
 	if err := cmd.Timeout(time.Minute * 5).Run(); err != nil {
-		util.LogDebugInfo()
 		return err
 	}
 

--- a/enterprise-suite/gotests/util/util.go
+++ b/enterprise-suite/gotests/util/util.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
 	"github.com/onsi/ginkgo"
 )
 
@@ -301,27 +300,4 @@ func IndentJson(in string) string {
 		panic(err)
 	}
 	return buf.String()
-}
-
-func LogDebugInfo() {
-	LogG("\n********************************************\nPrinting debug information:\n\n")
-
-	debugCmds := []string{
-		"get events --sort-by=.metadata.resourceVersion",
-		"logs -lapp.kubernetes.io/name=lightbend-console,app.kubernetes.io/component=console-frontend --all-containers",
-		"logs -lapp.kubernetes.io/name=lightbend-console,app.kubernetes.io/component=console-frontend --all-containers -p",
-		"logs -lapp.kubernetes.io/name=lightbend-console,app.kubernetes.io/component=console-backend --all-containers",
-		"logs -lapp.kubernetes.io/name=lightbend-console,app.kubernetes.io/component=console-backend --all-containers -p",
-		"logs -lapp.kubernetes.io/name=lightbend-console,app.kubernetes.io/component=grafana --all-containers",
-		"logs -lapp.kubernetes.io/name=lightbend-console,app.kubernetes.io/component=grafana --all-containers -p",
-	}
-
-	for _, cmd := range debugCmds {
-		kubectlArgs := []string{"-n", args.ConsoleNamespace}
-		kubectlArgs = append(kubectlArgs, strings.Split(cmd, " ")...)
-		if err := Cmd("kubectl", kubectlArgs...).PrintCommand().Run(); err != nil {
-			LogG("Could not gather debug info: %v\n", err)
-		}
-		LogG("\n")
-	}
 }

--- a/enterprise-suite/scripts/run-e2e-tests.sh
+++ b/enterprise-suite/scripts/run-e2e-tests.sh
@@ -18,33 +18,10 @@ setup
 echo "Running tests"
 cd $script_dir/../tests/e2e
 
-# run the e2e test
-set +e
-
 npm run e2e:demo-app-setup
-if [[ "$?" != "0" ]]; then
-    diagnostics
-    exit 1
-fi
-
 npm install
-if [[ "$?" != "0" ]]; then
-    diagnostics
-    exit 1
-fi
-
 npm run e2e:patch-minikube-ip
-if [[ "$?" != "0" ]]; then
-    diagnostics
-    exit 1
-fi
-
 npm run e2e:wait-es-services
-if [[ "$?" != "0" ]]; then
-    diagnostics
-    exit 1
-fi
-
 if [[ "$subset" == "all" ]]; then
     npm run e2e:travis-prs
 elif [[ "$subset" == "1" ]]; then
@@ -55,8 +32,3 @@ else
     echo "wrong parameter $subset for run-e2e-tests.sh"
     exit 1
 fi
-if [[ "$?" != "0" ]]; then
-    diagnostics
-    exit 1
-fi
-set -e

--- a/enterprise-suite/tests/setup_minikube.sh
+++ b/enterprise-suite/tests/setup_minikube.sh
@@ -14,14 +14,6 @@ function test_context() {
     echo minikube
 }
 
-function diagnostics() {
-    # diagnostics
-    minikube status
-    kubectl get namespace
-    kubectl get pod -n ${NAMESPACE}
-    kubectl get events -n ${NAMESPACE}
-}
-
 function setup() {
     kubectl create namespace ${NAMESPACE}
     if [ "${NAMESPACE}" != "${TILLER_NAMESPACE}" ]; then


### PR DESCRIPTION
After seeing what @katsutoxin had done in `es-console-spa` I thought it would be nice to use CircleCI steps to inspect the cluster as that way we can show or hide as much detail as we want.

See https://github.com/lightbend/es-console-spa/pull/556 for the details behind this Orb and an example of a build which fails.

It turned out that `nginx_tet.go` already has retries built in by using `urls.Get`. Granted it is only 5 seconds but I was hesitant to make it any longer without understand what is actually causing the delay.

Fixes lightbend/console-backend#757.