### PR TITLE
Support namespaces opt-in to scrape

### DIFF
--- a/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
+++ b/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
@@ -155,6 +155,7 @@ var _ = Describe("all:prometheus", func() {
 
 	Context("kube-state-metrics", func() {
 		It("should only scrape a single instance", func() {
+			time.Sleep(11 * time.Second)
 			query := fmt.Sprintf(`kube_pod_status_ready{namespace="%s", es_workload="console-backend", condition="true"} == 1`, args.ConsoleNamespace)
 			err := util.WaitUntilSuccess(util.MedWait, func() error {
 				return prom.HasNData(1, query)

--- a/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
+++ b/enterprise-suite/gotests/tests/prometheus/prometheus_test.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/args"
 	"github.com/lightbend/console-charts/enterprise-suite/gotests/testenv"

--- a/enterprise-suite/templates/kube-state-metrics-deployment.yaml
+++ b/enterprise-suite/templates/kube-state-metrics-deployment.yaml
@@ -45,6 +45,7 @@ spec:
           image: {{ .Values.kubeStateMetricsImage }}:{{ .Values.kubeStateMetricsVersion }}
           args:
             - --port=8080
+            - --namespace={{ .Values.kubeStateMetricsScrapeNamespaces }}
             - --telemetry-port=8081
           resources:
             requests:
@@ -53,4 +54,3 @@ spec:
           ports:
             - name: metrics
               containerPort: 8080
-

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -21,7 +21,7 @@ elasticsearchVersion: 7.3.2
 # jimmidyson/configmap-reload
 configMapReloadVersion: v0.2.2
 # gcr.io/google_containers/kube-state-metrics
-kubeStateMetricsVersion: v1.2.0
+kubeStateMetricsVersion: v1.3.0
 # lightbend/go-dnsmasq
 goDnsmasqVersion: v0.1.7-1
 # alpine
@@ -151,6 +151,12 @@ esGrafanaEnvVars:
 #  GF_SMTP_HOST: smtp.gmail.com:465
 #  GF_SMTP_USER: username
 #  GF_SMTP_PASSWORD: password
+
+#################################################
+# scrape metric from multiple namespaces
+#
+# Comma-separated list of namespaces to be enabled. "" for all namespaces
+kubeStateMetricsScrapeNamespaces: ""
 
 #################################################
 # Deprecated

--- a/operator/manifests/console_cr.yaml
+++ b/operator/manifests/console_cr.yaml
@@ -47,7 +47,8 @@ spec:
   imagePullPolicy: IfNotPresent
   kibanaImage: kibana
   kubeStateMetricsImage: gcr.io/google_containers/kube-state-metrics
-  kubeStateMetricsVersion: v1.2.0
+  kubeStateMetricsVersion: v1.3.0
+  kubeStateMetricsScrapeNamespaces: ""
   logstashImage: logstash
   minikube: false
   podUID: null

--- a/operator/manifests/console_cr.yaml
+++ b/operator/manifests/console_cr.yaml
@@ -47,8 +47,8 @@ spec:
   imagePullPolicy: IfNotPresent
   kibanaImage: kibana
   kubeStateMetricsImage: gcr.io/google_containers/kube-state-metrics
-  kubeStateMetricsVersion: v1.3.0
   kubeStateMetricsScrapeNamespaces: ""
+  kubeStateMetricsVersion: v1.3.0
   logstashImage: logstash
   minikube: false
   podUID: null


### PR DESCRIPTION
To test it in local

step 1. create es-demo app in namespace demo1/demo2/demo3
```
kubectl create ns demo1
kubectl create ns demo2
kubectl create ns demo3
kubectl apply -f ./enterprise-suite/tests/e2e/config/es-demo.yaml -n demo1
kubectl apply -f ./enterprise-suite/tests/e2e/config/es-demo.yaml -n demo2
kubectl apply -f ./enterprise-suite/tests/e2e/config/es-demo.yaml -n demo3
```

step 2. 

modify file `enterprise-suite/values.yaml` , 
change line 
```
kubeStateMetricsScrapeNamespaces: ""
```
to
```
kubeStateMetricsScrapeNamespaces: "demo1,demo3"
```
step 3. 
Install lightbend console with command 
```
cd enterprise-suite
./scripts/lbc.py install --local-chart=. --namespace lightbend  --set exposeServices=NodePort
```

step 4. check ui and see if it scrape demo1 and demo3 namespaces

-----------------

The usage scenario we imagine for customers would be to define a local yaml file that provides the override for ```kubeStateMetricsScrapeNamespaces``` only; e.g. values.yaml like so:
```kubeStateMetricsScrapeNamespaces: "demo1,demo3"```

You then reference this file, as an override/overlay, like so:

```./scripts/lbc.py install --local-chart=. --namespace lightbend  --set exposeServices=NodePort -- --values=values.yaml```

This example is predicated on having the console-charts pulled locally; so we need to verify that there is no issue when a customer pulls down our install script only and follows the same pattern