### PR TITLE
Add helm 3 support

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -639,8 +639,8 @@ def install(creds_file):
                     execute('helm install {} {} {}'.format(args.helm_name, chart_name, full_args))
     finally:
         if tempdir:
-            if args.keep_temp:
-                printout('info: Keeping temporary directory: ', tempdir)
+            if args.keep_chart:
+                printout('info: Keeping downloaded chart: ', tempdir)
             else:
                 shutil.rmtree(tempdir)
 
@@ -866,7 +866,7 @@ def setup_args(argv):
                          action='store_true')
     install.add_argument('--set', help='set a helm chart value, can be repeated for multiple values', type=str,
                          action='append')
-    install.add_argument('--keep-temp', help='does not delete the temporary directory', action='store_true')
+    install.add_argument('--keep-chart', help='does not delete the downloaded chart', action='store_true')
 
 
     # Common arguments for install and uninstall

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -137,6 +137,7 @@ def execute(cmd, can_fail=False, print_to_stdout=False):
 
 version_re = re.compile(r'(?:(?P<major>[0-9]+)\.(?P<minor>[0-9]+)(?P<patch>\.[0-9]+)?)')
 
+
 def require_version(cmd, required_version, max_version=None):
     # Use first word as a program name in messages
     name = cmd.partition(' ')[0]

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -155,10 +155,10 @@ def require_version(cmd, required_version, max_version=None):
                 if max_version is None or current < LooseVersion(max_version):
                     return match.groupdict()
                 else:
-                    fail("Installed version of {} is too new. Found: {}, required: {}"
+                    fail("Installed version of {} is too new. Found {} but the newest supported version is {}."
                         .format(name, current, max_version))
             else:
-                fail("Installed version of {} is too old. Found: {}, required: {}"
+                fail("Installed version of {} is too old. Found {} but the oldest supported version is {}."
                     .format(name, current, required))
 
     # Non-critical warning
@@ -311,10 +311,9 @@ def helm_migration_check():
             fail('\nwarning: Failed to check for legacy helm 2 installations.')
         elif stdout != '':
             message = (
-                '\nerror: Detected a previous Console installation which was installed with helm 2 '
-                'which has not been migrated to helm 3.\n'
-                'You must migrate these manually by following the instructions on '
-                'https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/'
+                '\nerror: Detected a previous Console installation which was installed with helm 2.\n'
+                'To use {} you must migrate the installation manually by '.format(helm_version) +
+                'following the instructions on https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/'
             )
             if platform.system() == 'Darwin':
                 message += '\nIf you are using homebrew then you can install both helm and helm@2'

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -313,7 +313,7 @@ def helm_migration_check():
         elif stdout != '':
             message = (
                 '\nerror: Detected a previous Console installation which was installed with helm 2.\n'
-                'To use {} you must migrate the installation manually by '.format(helm_version) +
+                'To use helm {} you must migrate the installation manually by '.format(helm_version) +
                 'following the instructions on https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/'
             )
             if platform.system() == 'Darwin':

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -155,7 +155,7 @@ def require_version(cmd, required_version, max_version=None):
                 if max_version is None or current < LooseVersion(max_version):
                     return match.groupdict()
                 else:
-                    fail("Installed version of {} is too new. Found {} but the newest supported version is {}."
+                    fail("Installed version of {} is too new. Found {} but the latest supported version is {}."
                         .format(name, current, max_version))
             else:
                 fail("Installed version of {} is too old. Found {} but the oldest supported version is {}."

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -879,8 +879,9 @@ def setup_args(argv):
         subparser.add_argument('rest',
                                help="any additional arguments separated by '--' will be passed to helm (eg. '-- --set usePersistentVolumes=false')",
                                nargs='*')
-        subparser.add_argument('--tiller-namespace', help='Tiller namespace. Used to detect legacy helm 2 installations.',
-                               default=os.environ.get('TILLER_NAMESPACE', 'kube-system'))
+        if helm_version != 2:
+            subparser.add_argument('--tiller-namespace', help='Tiller namespace. Used to detect legacy helm 2 installations (helm 3 only).',
+                                   default=os.environ.get('TILLER_NAMESPACE', 'kube-system'))
 
     # Common arguments for install, verify and dump
     for subparser in [install, verify, debug_dump]:
@@ -888,8 +889,9 @@ def setup_args(argv):
                                required=True)
 
     # Namespace is also required for uninstall if using helm3
-    uninstall.add_argument('--namespace', help='namespace to install console into/where it is installed. Required for helm 3.',
-                           required=helm_version > 2)
+    if helm_version != 2:
+        uninstall.add_argument('--namespace', help='namespace to install console into/where it is installed (helm 3 only)',
+                               required=helm_version > 2)
 
     # Common arguments for all subparsers
     for subparser in [install, uninstall, verify, debug_dump]:


### PR DESCRIPTION
All of the installer subcommands should now work with both helm 2 and 3.

If you do an install of console 1.2.4 with helm 2 and then try and to an install of 1.2.5 with helm 3 it should detect the old installation and fail as manual migrations steps are required. Once doing the migration the install should then succeed.