### PR TITLE
support k8s 1.16

### DIFF
--- a/enterprise-suite/console-api/prometheus.yml
+++ b/enterprise-suite/console-api/prometheus.yml
@@ -53,18 +53,18 @@ scrape_configs:
 
     # These are metric_relabel_configs since the source labels come from the scraped `/metrics`.
     metric_relabel_configs:
-      - source_labels: [pod_name]
+      - source_labels: [pod]
         target_label: kubernetes_pod_name
       # pause containers have all the network stats for a pod
-      - source_labels: [container_name, __name__]
+      - source_labels: [container, __name__]
         regex: POD;container_(network).*
-        target_label: container_name
+        target_label: container
       # drop all other pause container stats
-      - source_labels: [container_name]
+      - source_labels: [container]
         regex: POD
         action: drop
       # drop system containers with no name
-      - source_labels: [container_name]
+      - source_labels: [container]
         regex: ^$
         action: drop
       # drop high cardinality debug metrics

--- a/enterprise-suite/templates/kube-state-metrics-role.yaml
+++ b/enterprise-suite/templates/kube-state-metrics-role.yaml
@@ -14,6 +14,7 @@ rules:
   - configmaps
   - secrets
   - nodes
+  - nodes/proxy
   - pods
   - services
   - resourcequotas
@@ -23,23 +24,49 @@ rules:
   - persistentvolumes
   - namespaces
   - endpoints
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+    - cronjobs
+    - jobs
   verbs: ["list", "watch"]
 - apiGroups: ["extensions"]
   resources:
   - daemonsets
   - deployments
+  - ingresses
   - replicasets
   verbs: ["list", "watch"]
-- apiGroups: ["apps"]
+- apiGroups: ["policy"]
   resources:
-  - statefulsets
+    - poddisruptionbudgets
   verbs: ["list", "watch"]
-- apiGroups: ["batch"]
+- apiGroups: ["admissionregistration.k8s.io"]
   resources:
-  - cronjobs
-  - jobs
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
   verbs: ["list", "watch"]
-- apiGroups: ["autoscaling"]
+- apiGroups: ["certificates.k8s.io"]
   resources:
-  - horizontalpodautoscalers
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclasses
+  - volumeattachments
   verbs: ["list", "watch"]

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -21,7 +21,7 @@ elasticsearchVersion: 7.3.2
 # jimmidyson/configmap-reload
 configMapReloadVersion: v0.2.2
 # gcr.io/google_containers/kube-state-metrics
-kubeStateMetricsVersion: v1.3.0
+kubeStateMetricsVersion: v1.9.0
 # lightbend/go-dnsmasq
 goDnsmasqVersion: v0.1.7-1
 # alpine
@@ -62,8 +62,8 @@ busyboxImage: busybox
 #
 rbacApiVersion: rbac.authorization.k8s.io/v1
 apiGroupVersion: rbac.authorization.k8s.io
-deploymentApiVersion: apps/v1beta2
-daemonSetApiVersion: apps/v1beta2
+deploymentApiVersion: apps/v1
+daemonSetApiVersion: apps/v1
 
 #################################################
 # Resource Settings


### PR DESCRIPTION
This is an initial attempt to update the helm chart for k8s `1.16.x`.

- Updates the api versions to `apps/v1` due to the removal of the beta apis. 
- Updates cadvisor metrics that have been renamed (see the [release notes](https://v1-16.docs.kubernetes.io/docs/setup/release/notes/#removed-metrics)):
  - `pod_name` -> `pod`
  - `container_name` -> `container`
- Updates `kube-state-metrics` to v1.9.0 (the minimum version to support k8s `1.16.x`)
- Updates the rbac role:
  - Adds the proper permissions to collect cadvisor metrics (see https://github.com/linkerd/linkerd2/pull/1142).
  - Adds additional apiGroups for resources that `kube-state-metrics` now accesses.