### PR TITLE
Update kube-state-metrics-role.yaml for kube-state-metrics up to 1.8.0

### DIFF
--- a/enterprise-suite/templates/kube-state-metrics-role.yaml
+++ b/enterprise-suite/templates/kube-state-metrics-role.yaml
@@ -29,10 +29,14 @@ rules:
   - daemonsets
   - deployments
   - replicasets
+  - ingresses
   verbs: ["list", "watch"]
 - apiGroups: ["apps"]
   resources:
   - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
   verbs: ["list", "watch"]
 - apiGroups: ["batch"]
   resources:
@@ -42,4 +46,16 @@ rules:
 - apiGroups: ["autoscaling"]
   resources:
   - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclasses
   verbs: ["list", "watch"]


### PR DESCRIPTION
This allows one to use `kube-state-metrics` v1.8.0 with k8s 1.15 without getting permission errors.