### PR TITLE
Changes for Cluster Metrics graphs (k8s <= 1.16)

### DIFF
--- a/enterprise-suite/console-api/prometheus.yml
+++ b/enterprise-suite/console-api/prometheus.yml
@@ -53,18 +53,18 @@ scrape_configs:
 
     # These are metric_relabel_configs since the source labels come from the scraped `/metrics`.
     metric_relabel_configs:
-      - source_labels: [pod_name]
+      - source_labels: [pod]
         target_label: kubernetes_pod_name
       # pause containers have all the network stats for a pod
-      - source_labels: [container_name, __name__]
+      - source_labels: [container, __name__]
         regex: POD;container_(network).*
-        target_label: container_name
+        target_label: container
       # drop all other pause container stats
-      - source_labels: [container_name]
+      - source_labels: [container]
         regex: POD
         action: drop
       # drop system containers with no name
-      - source_labels: [container_name]
+      - source_labels: [container]
         regex: ^$
         action: drop
       # drop high cardinality debug metrics

--- a/enterprise-suite/console-api/prometheus.yml
+++ b/enterprise-suite/console-api/prometheus.yml
@@ -53,19 +53,30 @@ scrape_configs:
 
     # These are metric_relabel_configs since the source labels come from the scraped `/metrics`.
     metric_relabel_configs:
+      # 'pod_name' for k8s < 1.16, 'pod' for k8s > 1.13 (overlap for 1.14, 1.15)
+      - source_labels: [pod_name]
+        target_label: kubernetes_pod_name
       - source_labels: [pod]
         target_label: kubernetes_pod_name
       # pause containers have all the network stats for a pod
+      # 'container_name' for k8s < 1.16, 'container' for k8s > 1.13 (overlap for 1.14, 1.15)
+      - source_labels: [container_name, __name__]
+        regex: POD;container_(network).*
+        target_label: container_name
       - source_labels: [container, __name__]
         regex: POD;container_(network).*
         target_label: container
       # drop all other pause container stats
+      - source_labels: [container_name]
+        regex: POD
+        action: drop
       - source_labels: [container]
         regex: POD
         action: drop
       # drop system containers with no name
-      - source_labels: [container]
-        regex: ^$
+      # Need both labels to be empty or we'll drop everything
+      - source_labels: [container_name, container]
+        regex: ^;$
         action: drop
       # drop high cardinality debug metrics
       - source_labels: [__name__]

--- a/enterprise-suite/templates/kube-state-metrics-role.yaml
+++ b/enterprise-suite/templates/kube-state-metrics-role.yaml
@@ -72,5 +72,6 @@ rules:
   verbs: ["list", "watch"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources:
+  - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs: ["list", "watch"]

--- a/enterprise-suite/templates/kube-state-metrics-role.yaml
+++ b/enterprise-suite/templates/kube-state-metrics-role.yaml
@@ -15,6 +15,7 @@ rules:
   - configmaps
   - secrets
   - nodes
+  - nodes/proxy
   - pods
   - services
   - resourcequotas
@@ -24,16 +25,20 @@ rules:
   - persistentvolumes
   - namespaces
   - endpoints
-  verbs: ["list", "watch"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["extensions"]
   resources:
   - daemonsets
   - deployments
   - replicasets
+  - ingresses
   verbs: ["list", "watch"]
 - apiGroups: ["apps"]
   resources:
   - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
   verbs: ["list", "watch"]
 - apiGroups: ["batch"]
   resources:
@@ -43,4 +48,29 @@ rules:
 - apiGroups: ["autoscaling"]
   resources:
   - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs: ["list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs: ["list", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - validatingwebhookconfigurations
   verbs: ["list", "watch"]


### PR DESCRIPTION
These changes, in conjunction with appropriate `values.yaml` mods, get the Cluster Metrics page to work in Grafana.

These changes are appropriate for the previous k8s versions we used to work with and now also up to and including 1.16.  _For k8s 1.15 and beyond, the user must create a `values.yaml` file to apply at install time.  cf. https://github.com/lightbend/console-charts/pull/476#issuecomment-669521064._

---------

(This is the original comment.  Ignore now...)

~~This is a Draft PR at this time as I don't think these changes will be backwards compatible.  (ie won't work on k8s < 1.14)~~

If trying to install, use a `values.yaml` file with, for now:
```\kubeStateMetricsImage: quay.io/coreos/kube-state-metrics
kubeStateMetricsVersion: v1.9.7

deploymentApiVersion: apps/v1
daemonSetApiVersion: apps/v1
```