### PR TITLE
Move to Prometheus 2.19.3

### DIFF
--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -15,7 +15,7 @@ esMonitorVersion: v1.2.5
 # lightbend-docker-commercial-registry.bintray.io/enterprise-suite/es-grafana
 esGrafanaVersion: v0.3.4
 # prom/prometheus
-prometheusVersion: v2.9.2
+prometheusVersion: v2.19.3
 # elasticsearch and logstash
 elasticsearchVersion: 7.3.2
 # jimmidyson/configmap-reload

--- a/operator/manifests/console_cr.yaml
+++ b/operator/manifests/console_cr.yaml
@@ -55,7 +55,7 @@ spec:
   prometheusDomain: prometheus.io
   prometheusImage: prom/prometheus
   prometheusMemoryRequest: 250Mi
-  prometheusVersion: v2.9.2
+  prometheusVersion: v2.19.3
   prometheusVolumeSize: 256Gi
   rbacApiVersion: rbac.authorization.k8s.io/v1
   usePersistentVolumes: true


### PR DESCRIPTION
Prometheus versions newer than 2.19.3 manage the Prometheus WAL file differently, so one wouldn't (easily) be able to go back to v2.9.2 if they wanted.  cf. https://github.com/prometheus/prometheus/releases/tag/v2.20.0

We'll have to test thoroughly before we go beyond this.