### PR TITLE
helm3 compat: Add --force-update to helm repo add

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -539,7 +539,7 @@ def install(creds_file):
             chart_file = args.local_chart
         else:
             chart_name = "{}/{}".format(args.repo_name, args.chart)
-            execute('helm repo add {} {}'.format(args.repo_name, args.repo))
+            execute('helm repo add --force-update {} {}'.format(args.repo_name, args.repo))
             execute('helm repo update')
             tempdir = make_fetchdir()
             chart_file = fetch_remote_chart(tempdir)


### PR DESCRIPTION
`helm repo add ...` under v2 would be fine if you added the same repo multiple times (it would by default overwrite the repo name with the provided URL).

As of v3, if you attempt to add a repo whose name already exists, you get an error. Seen on [this support ticket](https://support.lightbend.com/support/lightbend/ShowHomePage.do#Cases/dv/427921000009056037)

This PR adds the `--force-update` so that the customer can rerun the lbc.py script without error.