### PR TITLE
set-tools-for-debian.sh to use new stable helm repo

### DIFF
--- a/scripts/setup-tools-for-debian.sh
+++ b/scripts/setup-tools-for-debian.sh
@@ -30,7 +30,7 @@ curl -LO https://storage.googleapis.com/kubernetes-helm/${helm_file}
 echo "0fa2ed4983b1e4a3f90f776d08b88b0c73fd83f305b5b634175cb15e61342ffe ${helm_file}" | sha256sum --check
 tar xzvf ${helm_file}
 sudo cp linux-amd64/helm /usr/local/bin/
-helm init -c
+helm init -c --stable-repo-url https://charts.helm.sh/stable
 
 # socat is needed for helm init --wait to work
 sudo apt-get install -y socat


### PR DESCRIPTION
The `release_nightly` CI build step is failing.  It fails when running `helm init` with
```
Error: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
```

This change should fix that, as suggested here:  https://stackoverflow.com/a/65404574/12957030