### PR TITLE
remove reference to es-grafana in Makefile

### DIFF
--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -74,7 +74,7 @@ lint-helm:  ## Run helm lint on chart files
 
 .PHONY: lint-json
 lint-json:  ## Test json files are well-formed
-	find $(CHART_DIR)/console-api $(CHART_DIR)/es-grafana -name '*.json' | xargs -tn 1 jq . >/dev/null
+	find $(CHART_DIR)/console-api -name '*.json' | xargs -tn 1 jq . >/dev/null
 
 .PHONY: lint-promql
 lint-promql:  ## Test promql bits are well-formed

--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -41,6 +41,7 @@ ginkgo_args := -r -compilers=2 --progress --failFast --randomizeAllSpecs --slowS
 .PHONY: run-tests-minikube
 run-tests-minikube:
 	go mod init tests
+	go mod vendor
 	ginkgo --focus='minikube:.*' $(ginkgo_args)
 
 .PHONY: run-tests-openshift

--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -41,6 +41,7 @@ ginkgo_args := -r -compilers=2 --progress --failFast --randomizeAllSpecs --slowS
 .PHONY: run-tests-minikube
 run-tests-minikube:
 	go mod init tests
+	go mod tidy
 	go mod vendor
 	ginkgo --focus='minikube:.*' $(ginkgo_args)
 

--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -52,9 +52,9 @@ format:
 
 .PHONY: setup-tools
 setup-tools:
-        git clone https://github.com/udhos/update-golang
-        cd update-golang
-        ./update-golang.sh
+	git clone https://github.com/udhos/update-golang
+	cd update-golang
+	sudo ./update-golang.sh
 	go get -u golang.org/x/lint/golint
 	go get -u golang.org/x/tools/cmd/goimports
 	go get -u github.com/onsi/ginkgo/ginkgo

--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -40,6 +40,7 @@ ginkgo_args := -r -compilers=2 --progress --failFast --randomizeAllSpecs --slowS
 
 .PHONY: run-tests-minikube
 run-tests-minikube:
+	go mod init tests
 	ginkgo --focus='minikube:.*' $(ginkgo_args)
 
 .PHONY: run-tests-openshift

--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -52,6 +52,9 @@ format:
 
 .PHONY: setup-tools
 setup-tools:
+        git clone https://github.com/udhos/update-golang
+        cd update-golang
+        ./update-golang.sh
 	go get -u golang.org/x/lint/golint
 	go get -u golang.org/x/tools/cmd/goimports
 	go get -u github.com/onsi/ginkgo/ginkgo

--- a/enterprise-suite/gotests/Makefile
+++ b/enterprise-suite/gotests/Makefile
@@ -53,8 +53,7 @@ format:
 .PHONY: setup-tools
 setup-tools:
 	git clone https://github.com/udhos/update-golang
-	cd update-golang
-	sudo ./update-golang.sh
+	sudo /home/circleci/go/src/github.com/lightbend/console-charts/enterprise-suite/gotests/update-golang/update-golang.sh
 	go get -u golang.org/x/lint/golint
 	go get -u golang.org/x/tools/cmd/goimports
 	go get -u github.com/onsi/ginkgo/ginkgo

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -207,12 +207,12 @@ class HelmCommandsTest():
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         self.expect_helm_template()
-        lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console'])
+        lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console', '--creds='+self.creds_file])
 
     def test_export_yaml_local_chart(self):
         self.expect_helm_version()
         self.expect_helm_template(chart='chart.tgz')
-        lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console', '--local-chart=chart.tgz'])
+        lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console', '--local-chart=chart.tgz'], '--creds='+self.creds_file])
 
     def test_export_yaml_creds(self):
         self.expect_helm_version()
@@ -588,7 +588,7 @@ class HelmV332AndAboveCommandsTest(HelmV3CommandsTest, unittest.TestCase):
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         self.expect_helm_template()
-        lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console'])
+        lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console'], '--creds='+self.creds_file])
 
 
 if __name__ == '__main__':

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -212,7 +212,7 @@ class HelmCommandsTest():
     def test_export_yaml_local_chart(self):
         self.expect_helm_version()
         self.expect_helm_template(chart='chart.tgz')
-        lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console', '--local-chart=chart.tgz'], '--creds='+self.creds_file])
+        lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console', '--local-chart=chart.tgz', '--creds='+self.creds_file])
 
     def test_export_yaml_creds(self):
         self.expect_helm_version()
@@ -588,7 +588,7 @@ class HelmV332AndAboveCommandsTest(HelmV3CommandsTest, unittest.TestCase):
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm fetch .* es-repo/enterprise-suite')
         self.expect_helm_template()
-        lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console'], '--creds='+self.creds_file])
+        lbc.main(['install', '--namespace=lightbend', '--skip-checks', '--export-yaml=console', '--creds='+self.creds_file])
 
 
 if __name__ == '__main__':

--- a/enterprise-suite/scripts/validate-promql.sh
+++ b/enterprise-suite/scripts/validate-promql.sh
@@ -9,39 +9,39 @@ if ! command -v promtool > /dev/null; then
     exit 1
 fi
 
-if ! command -v jq > /dev/null; then
-    echo "please install jq"
-    exit 1
-fi
+# if ! command -v jq > /dev/null; then
+#     echo "please install jq"
+#     exit 1
+# fi
 
-echo "checking promql in enterprise-suite/es-grafana/*.json"
+# echo "checking promql in enterprise-suite/es-grafana/*.json"
 
-# check_expr wraps one promql expression in a mock rule file for promtool.
-# We test one expression at a time to more easily report the expression that
-# failed, as promtool will report line number problems instead of expr bugs.
-check_expr() {
-  echo "$*"
-  printf 'groups:\n- name: group\n  rules:\n  - record: metric\n    expr: %s\n' "$*" | promtool check rules /dev/stdin 2>&1
-}
+# # check_expr wraps one promql expression in a mock rule file for promtool.
+# # We test one expression at a time to more easily report the expression that
+# # failed, as promtool will report line number problems instead of expr bugs.
+# check_expr() {
+#   echo "$*"
+#   printf 'groups:\n- name: group\n  rules:\n  - record: metric\n    expr: %s\n' "$*" | promtool check rules /dev/stdin 2>&1
+# }
 
-# extract our grafana plugin expressions as a virtual file, one row per expr
-prom_lines() {
-  jq -r '.[].promQL[]| if type=="object" then .expr else . end' "$1" |
-    sed -e 's/ContextTags[,]*//g' -e 's/\$__interval/10s/'
-}
+# # extract our grafana plugin expressions as a virtual file, one row per expr
+# prom_lines() {
+#   jq -r '.[].promQL[]| if type=="object" then .expr else . end' "$1" |
+#     sed -e 's/ContextTags[,]*//g' -e 's/\$__interval/10s/'
+# }
 
-count=0
-for json in ${script_dir}/../es-grafana/*.json; do
-  prom_lines "$json" | while read -r promql; do
-    out=$( check_expr "$promql" ) || {
-      echo "error in $json"
-      echo "$out"
-      exit 1
-    }
-  done
+# count=0
+# for json in ${script_dir}/../es-grafana/*.json; do
+#   prom_lines "$json" | while read -r promql; do
+#     out=$( check_expr "$promql" ) || {
+#       echo "error in $json"
+#       echo "$out"
+#       exit 1
+#     }
+#   done
 
-  count=$(( count + $(prom_lines "$json"| wc -l) ))
-done
+#   count=$(( count + $(prom_lines "$json"| wc -l) ))
+# done
 
 echo "validated $count promql expressions"
 

--- a/enterprise-suite/scripts/validate-promql.sh
+++ b/enterprise-suite/scripts/validate-promql.sh
@@ -9,42 +9,6 @@ if ! command -v promtool > /dev/null; then
     exit 1
 fi
 
-# if ! command -v jq > /dev/null; then
-#     echo "please install jq"
-#     exit 1
-# fi
-
-# echo "checking promql in enterprise-suite/es-grafana/*.json"
-
-# # check_expr wraps one promql expression in a mock rule file for promtool.
-# # We test one expression at a time to more easily report the expression that
-# # failed, as promtool will report line number problems instead of expr bugs.
-# check_expr() {
-#   echo "$*"
-#   printf 'groups:\n- name: group\n  rules:\n  - record: metric\n    expr: %s\n' "$*" | promtool check rules /dev/stdin 2>&1
-# }
-
-# # extract our grafana plugin expressions as a virtual file, one row per expr
-# prom_lines() {
-#   jq -r '.[].promQL[]| if type=="object" then .expr else . end' "$1" |
-#     sed -e 's/ContextTags[,]*//g' -e 's/\$__interval/10s/'
-# }
-
-# count=0
-# for json in ${script_dir}/../es-grafana/*.json; do
-#   prom_lines "$json" | while read -r promql; do
-#     out=$( check_expr "$promql" ) || {
-#       echo "error in $json"
-#       echo "$out"
-#       exit 1
-#     }
-#   done
-
-#   count=$(( count + $(prom_lines "$json"| wc -l) ))
-# done
-
-echo "validated $count promql expressions"
-
 echo "checking enterprise-suite/console-api/static-rules.yml"
 cat ${script_dir}/../console-api/static-rules.yml |
   ( printf 'groups:\n- name: group\n  rules:\n' ; sed -e 's/^/  /') |


### PR DESCRIPTION
PR checks are failing in Circle because the `make lint-json` target is failing.  This fixes that.  (The `es-grafana` directory was removed in PR https://github.com/lightbend/console-charts/pull/408 (aka a _long_ time ago...).