### PR TITLE
Fix for network metrics against Azure AKS environment. - Local

### DIFF
--- a/enterprise-suite/console-api/prometheus.yml
+++ b/enterprise-suite/console-api/prometheus.yml
@@ -66,6 +66,18 @@ scrape_configs:
       - source_labels: [container, __name__]
         regex: POD;container_(network).*
         target_label: container
+      # Azure AKS exports network metrics in a different way.
+      # The container_name is always empty. We must rely on both namespace and pod labels to identify such traffic.
+      - source_labels: [container_name, namespace, kubernetes_pod_name, __name__ ]
+        regex: ;(.+);(.+);container_network.*
+        target_label: container_name
+        action: replace
+        replacement: ${1}-${2}
+      - source_labels: [container, namespace, kubernetes_pod_name, __name__ ]
+        regex: ;(.+);(.+);container_network.*
+        target_label: container
+        action: replace
+        replacement: ${1}-${2}
       # drop all other pause container stats
       - source_labels: [container_name]
         regex: POD


### PR DESCRIPTION
# AKS Network Metrics fix
This merge request contains fix/workaround for AKS network metrics issue

## Problem
When previewing Cluster Metrics dashboard provided by Console, there is no data for both received and sent network traffic.
During investigation, it turned out that cAdvisor is exporting, for non-system pods/containers, metrics matching following schema:
`container_network_(receive|transmit)_bytes_total{container="",id="some_id",image="some_image",interface="some_interface",namespace="non_empty_namespace",pod="non_empty_pod_name"}`,
while for system metrics, the `container`, `pod`, `namespace` labels are always empty.
It looks like AKS is exporting metrics for pause containers with `container` label set to empty. 

The rules in `prometheus.yaml` are filtering out those metrics, because `container` and `container_name` labels are empty and since are not expected to be pause pod.

## Possible solution
As presented in changed files, the fix for this issue requires adding special case in `prometheus.yaml`